### PR TITLE
use last version of report engine to fix "Failed at query..." 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,13 @@ repositories {
     // https://jira.pentaho.com/browse/PDI-18983
 }
 
+project.ext.pentahoVersion = '7.0.0.6-95'
+
 dependencyManagement {
     dependencies {
-        dependency 'pentaho-reporting-engine:pentaho-reporting-engine-classic-core:3.9.1-GA'
 
-        dependencySet(group: 'pentaho-reporting-engine', version: '3.9.1-GA') {
+        dependencySet(group: 'pentaho-reporting-engine', version: pentahoVersion) {
+            entry 'pentaho-reporting-engine-classic-core'
             entry 'pentaho-reporting-engine-classic-extensions'
             entry 'pentaho-reporting-engine-classic-extensions-scripting'
             entry 'pentaho-reporting-engine-wizard-core'
@@ -27,7 +29,7 @@ dependencyManagement {
             entry 'pentaho-reporting-engine-wizard-xul'
         }
 */
-        dependencySet(group: 'pentaho-library', version: '1.2.8') {
+        dependencySet(group: 'pentaho-library', version: pentahoVersion) {
             entry 'libbase'
             entry 'libdocbundle'
             entry 'libfonts'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ project.ext.pentahoVersion = '7.0.0.6-95'
 
 dependencyManagement {
     dependencies {
-
+        dependency 'org.openjdk.nashorn:nashorn-core:15.1'
         dependencySet(group: 'pentaho-reporting-engine', version: pentahoVersion) {
             entry 'pentaho-reporting-engine-classic-core'
             entry 'pentaho-reporting-engine-classic-extensions'
@@ -76,7 +76,9 @@ dependencies {
         'pentaho-library:librepository',
         'pentaho-library:libserializer',
         'pentaho-library:libsparkline',
-        'pentaho-library:libxml'
+        'pentaho-library:libxml',
+
+        'org.openjdk.nashorn:nashorn-core'
     )
     
     testImplementation(


### PR DESCRIPTION
Hello there, after a lot of testing and trying to make this working correctly, i finally made it!

So i tried this with fineract v1.5.0, not sure about the older versions.

So you just need to update the version of the report engine and it should work.

Maybe you will get an error like `Unable to load specified driver class: org.gjt.mm.mysql.Driver.` but it should connect anyway, at least worked for me. 

Also i tried using mysql-connector-java-8.0.23.jar but it doesn't work with the same error mentioned. To fix this i had to go to the report designer and open a report and edit the connection to a "Generic database" and put the correct driver class name "com.mysql.jdbc.Driver". This is related to this issue: https://stackoverflow.com/questions/56683910/pantaho-mysql-8-connection-error-driver-class-org-gjt-mm-mysql-driver-could-no

