### PR TITLE
using asm-9.1 dependency set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,20 +8,33 @@ repositories {
     jcenter()
 
     maven { url 'https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/'  }
-    maven { url 'https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/'  }
+    maven { url 'https://mvnrepository.com/artifact/org.ow2.asm/asm'  }
     
     // maven { url 'https://nexus.pentaho.org/content/groups/omni/' }
+    // // https://mvnrepository.com/artifact/org.ow2.asm/asm
+// implementation group: 'org.ow2.asm', name: 'asm', version: '9.1'
+//org.ow2.asm:asm:9.1
     // https://github.com/pentaho/mondrian/issues/1054
     // https://jira.pentaho.com/browse/PDI-18983
 }
 
 project.ext.pentahoVersion = '7.0.0.6-95'
-apply plugin: 'war'
+project.ext.asmVersion = '9.1'
 
 dependencyManagement {
     dependencies {
         dependency 'org.openjdk.nashorn:nashorn-core:15.1'
         dependency 'org.codehaus.groovy:groovy-all:3.0.8'
+        // dependency 'org.ow2.asm:asm:9.1'
+
+        dependencySet(group: 'org.ow2.asm', version: asmVersion) {
+            entry 'asm'
+            entry 'asm-analysis'
+            entry 'asm-commons'
+            entry 'asm-tree'
+            entry 'asm-util'       
+        }
+
         dependencySet(group: 'pentaho-reporting-engine', version: pentahoVersion) {
             entry 'pentaho-reporting-engine-classic-core'
             entry 'pentaho-reporting-engine-classic-extensions'
@@ -83,7 +96,14 @@ dependencies {
         'pentaho-library:libxml',
 
         'org.openjdk.nashorn:nashorn-core',
-        'org.codehaus.groovy:groovy-all'
+        'org.codehaus.groovy:groovy-all',
+
+        'org.ow2.asm:asm',
+        'org.ow2.asm:asm-analysis',
+        'org.ow2.asm:asm-commons',
+        'org.ow2.asm:asm-tree',
+        'org.ow2.asm:asm-util'
+        
     )
     
     testImplementation(
@@ -130,11 +150,7 @@ distributions {
                 from(jar)
             }
 
-            into('/lib') {
-                from(war)
-            }
-        
-            eachFile { FileCopyDetails fcp ->
+             eachFile { FileCopyDetails fcp ->
               fcp.relativePath = new RelativePath(true, fcp.relativePath.pathString.replace('fineract-pentaho/', ''))
             }
         }


### PR DESCRIPTION
After runing the command ./gradlew -x test distZip  i have noticed that a dependency org.ow2.asm:7.3.1 creates 5 jars in the lib folder.  When i transfer all these jars to tomcat\webapps\fineract-provider\WEB-INF\lib i realise that a newer  org.ow2.asm:9.1 is already available see image below
![image_2021_07_06T20_10_29_870Z](https://user-images.githubusercontent.com/22683654/124734372-90f87f80-df04-11eb-9800-181654cf60ef.png)


@adonay28  @bharathcgowda  so i upgraded to 9.1 in fineract-pentaho to avoid any challenges but i need to know if this is important 