### PR TITLE
ci: Add maven build workflow and enforce code formatting

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,28 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Source Code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'zulu'
+        cache: 'maven'
+
+    - name: Build with Maven
+      # -DskipTests: Compiles tests but does not run them (avoids localhost:8443 error)
+      # -B: Batch mode
+      # -U: Force update snapshots
+      run: mvn -B clean verify -U -DskipTests --file pom.xml

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -11,18 +11,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Source Code
-      uses: actions/checkout@v4
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'zulu'
-        cache: 'maven'
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+          cache: 'maven'
 
-    - name: Build with Maven
-      # -DskipTests: Compiles tests but does not run them (avoids localhost:8443 error)
-      # -B: Batch mode
-      # -U: Force update snapshots
-      run: mvn -B clean verify -U -DskipTests --file pom.xml
+      - name: Validate Code Formatting
+        # Enforce coding style guidelines immediately.
+        # Fails fast if the code does not adhere to the project's Spotless configuration.
+        run: mvn spotless:check --file pom.xml
+
+      - name: Build and Package
+        # Compiles the code and packages the JAR artifacts.
+        # Tests are currently skipped (-DskipTests) as integration tests require
+        # a running Fineract backend instance (localhost:8443) which is not
+        # available in this standard runner environment.
+        run: mvn -B clean package -U -DskipTests --file pom.xml


### PR DESCRIPTION
## Description
This PR introduces a GitHub Actions workflow to automatically validate build integrity and enforce code style on every Pull Request targeting the `develop` branch. It ensures that all incoming code compiles successfully and adheres to the project's formatting standards before review.

## Key Changes
* **CI Pipeline**: Added `.github/workflows/maven-build.yml` to trigger on `push` and `pull_request` events.
* **Environment Alignment**: configured the workflow to use **Zulu JDK 21**, ensuring consistency with the existing `jfrog-publish.yml` deployment workflow.
* **Code Style Enforcement**: Integrated `mvn spotless:check` as a blocking step. The build will fail immediately if code formatting violates the Google Java Style guidelines.
* **Artifact Verification**: Runs `mvn clean package` to verify that the application compiles and the JAR artifacts are generated correctly.

## Notes
* **Integration Tests**: The build runs with `-DskipTests` for now. The current integration tests (`PentahoReportsTest`) depend on a running local Fineract instance (`localhost:8443`), which is not available in the standard GitHub Runner environment.
    * *Future improvement:* We can introduce Testcontainers or Docker Compose to enable full integration testing in CI.
* **Caching**: Enabled Maven dependency caching (`~/.m2`) to optimize build times for future runs.
