### PR TITLE
MX-287: Isolate BIRT report execution from shared template state

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtDataSourceConfigurer.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtDataSourceConfigurer.java
@@ -9,9 +9,9 @@ package org.apache.fineract.infrastructure.report.service;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import javax.sql.DataSource;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
@@ -26,9 +26,6 @@ import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.eclipse.birt.report.model.api.SlotHandle;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Responsible for configuring BIRT report datasources with correct tenant connection details.

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtDataSourceConfigurer.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtDataSourceConfigurer.java
@@ -9,9 +9,9 @@ package org.apache.fineract.infrastructure.report.service;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import javax.sql.DataSource;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
@@ -26,6 +26,9 @@ import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.eclipse.birt.report.model.api.SlotHandle;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Responsible for configuring BIRT report datasources with correct tenant connection details.
@@ -130,6 +133,10 @@ public class BirtDataSourceConfigurer {
           log.trace("Successfully updated datasource: {}", dataSource.getName());
         } catch (Exception e) {
           log.error("Failed to update datasource: {}", dataSource.getName(), e);
+          throw reportErrorHandler.reportError(
+              "error.msg.reporting.datasource.configuration.failed",
+              "Failed to configure datasource: " + dataSource.getName(),
+              e);
         }
       }
     }

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactory.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactory.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import java.util.Locale;
+
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.eclipse.birt.report.engine.api.IReportEngine;
+import org.eclipse.birt.report.engine.api.IReportRunnable;
+import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.eclipse.birt.report.model.api.core.IDesignElement;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Creates execution-local BIRT report runnables from cached report templates.
+ *
+ * <p>The cached runnable returned by {@link BirtReportLoader} must be treated as immutable template
+ * state. Tenant-specific datasource values are written later in the execution flow, so each
+ * execution needs an isolated report design handle before datasource configuration occurs.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BirtReportExecutionFactory {
+
+  private final IReportEngine reportEngine;
+  private final BirtReportLoader reportLoader;
+  private final ReportErrorHandler reportErrorHandler;
+
+  /**
+   * Creates a per-execution runnable by copying the cached template design handle and opening a new
+   * runnable from that copied handle.
+   *
+   * @param reportName the base report name
+   * @param locale the requested locale, or {@code null}
+   * @return an execution-local runnable safe for tenant-specific datasource mutation
+   */
+  public IReportRunnable createExecutionRunnable(String reportName, Locale locale) {
+    try {
+      IReportRunnable template = reportLoader.loadReport(reportName, locale);
+      ReportDesignHandle templateHandle = (ReportDesignHandle) template.getDesignHandle();
+
+      IDesignElement copiedElement = templateHandle.copy();
+      ReportDesignHandle executionHandle = (ReportDesignHandle) copiedElement.getHandle(null);
+      
+      executionHandle.setFileName(template.getReportName());
+
+      IReportRunnable executionRunnable = reportEngine.openReportDesign(executionHandle);
+      log.debug("Created execution-local BIRT runnable for report: {}", reportName);
+      return executionRunnable;
+    } catch (PlatformDataIntegrityException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to create execution-local BIRT runnable for report: {}", reportName, e);
+      throw reportErrorHandler.reportError(
+          "error.msg.reporting.report.execution.copy.failed",
+          "Failed to create execution-local report design: " + reportName,
+          e);
+    }
+  }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactory.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactory.java
@@ -7,16 +7,14 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import java.util.Locale;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.eclipse.birt.report.engine.api.IReportEngine;
 import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.eclipse.birt.report.model.api.core.IDesignElement;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Creates execution-local BIRT report runnables from cached report templates.
@@ -49,7 +47,7 @@ public class BirtReportExecutionFactory {
 
       IDesignElement copiedElement = templateHandle.copy();
       ReportDesignHandle executionHandle = (ReportDesignHandle) copiedElement.getHandle(null);
-      
+
       executionHandle.setFileName(template.getReportName());
 
       IReportRunnable executionRunnable = reportEngine.openReportDesign(executionHandle);

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
 public class BirtReportingProcessServiceImpl implements ReportingProcessService {
 
   private final IReportEngine reportEngine;
-  private final BirtReportLoader reportLoader;
+  private final BirtReportExecutionFactory reportExecutionFactory;
   private final BirtDataSourceConfigurer dataSourceConfigurer;
   private final BirtParameterMapper parameterMapper;
   private final Map<String, BirtRenderer> birtRenderers;
@@ -51,13 +51,14 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
     log.info(
         "Generating BIRT report: {} | format: {} | locale: {}", reportName, outputType, locale);
 
+    IRunAndRenderTask task = null;
     try {
-      IReportRunnable design = reportLoader.loadReport(reportName, locale);
+      IReportRunnable design = reportExecutionFactory.createExecutionRunnable(reportName, locale);
       ReportDesignHandle designHandle = (ReportDesignHandle) design.getDesignHandle();
 
       dataSourceConfigurer.configureAll(designHandle);
 
-      IRunAndRenderTask task = reportEngine.createRunAndRenderTask(design);
+      task = reportEngine.createRunAndRenderTask(design);
       task.setErrorHandlingOption(IEngineTask.CANCEL_ON_ERROR);
 
       configureLocale(task, locale);
@@ -70,6 +71,14 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
       log.error("Failed to generate BIRT report: {}", reportName, e);
       throw new PlatformDataIntegrityException(
           "error.msg.reporting.error", "Report generation failed: " + e.getMessage(), e);
+    } finally {
+      if (task != null) {
+        try {
+          task.close();
+        } catch (Exception e) {
+          log.warn("Failed to close BIRT report task for report: {}", reportName, e);
+        }
+      }
     }
   }
 

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactoryTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactoryTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+import org.eclipse.birt.report.engine.api.IReportEngine;
+import org.eclipse.birt.report.engine.api.IReportRunnable;
+import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.eclipse.birt.report.model.api.core.IDesignElement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BirtReportExecutionFactory Tests")
+class BirtReportExecutionFactoryTest {
+
+  @Mock private IReportEngine reportEngine;
+  @Mock private BirtReportLoader reportLoader;
+  @Mock private ReportErrorHandler reportErrorHandler;
+
+  @InjectMocks private BirtReportExecutionFactory executionFactory;
+
+  @Test
+  @DisplayName("Should create execution runnable with independent design handle")
+  void shouldCreateExecutionRunnableWithIndependentDesignHandle() throws Exception {
+    IReportRunnable templateRunnable = mock(IReportRunnable.class);
+    IReportRunnable executionRunnable = mock(IReportRunnable.class);
+    ReportDesignHandle templateHandle = mock(ReportDesignHandle.class);
+    ReportDesignHandle executionHandle = mock(ReportDesignHandle.class);
+    IDesignElement copiedElement = mock(IDesignElement.class);
+
+    when(reportLoader.loadReport("sample", Locale.ENGLISH)).thenReturn(templateRunnable);
+    when(templateRunnable.getDesignHandle()).thenReturn(templateHandle);
+    when(templateRunnable.getReportName()).thenReturn("sample.rptdesign");
+    when(templateHandle.copy()).thenReturn(copiedElement);
+    when(copiedElement.getHandle(null)).thenReturn(executionHandle);
+    when(reportEngine.openReportDesign(executionHandle)).thenReturn(executionRunnable);
+    when(executionRunnable.getDesignHandle()).thenReturn(executionHandle);
+
+    IReportRunnable result = executionFactory.createExecutionRunnable("sample", Locale.ENGLISH);
+
+    assertSame(executionRunnable, result);
+    assertNotSame(templateHandle, result.getDesignHandle());
+    verify(reportEngine).openReportDesign(executionHandle);
+  }
+
+  @Test
+  @DisplayName("Should not mutate cached template when execution copy is modified")
+  void shouldNotMutateCachedTemplateWhenExecutionCopyIsModified() throws Exception {
+    IReportRunnable templateRunnable = mock(IReportRunnable.class);
+    IReportRunnable executionRunnable = mock(IReportRunnable.class);
+    ReportDesignHandle templateHandle = mock(ReportDesignHandle.class);
+    ReportDesignHandle executionHandle = mock(ReportDesignHandle.class);
+    IDesignElement copiedElement = mock(IDesignElement.class);
+
+    when(reportLoader.loadReport("sample", Locale.ENGLISH)).thenReturn(templateRunnable);
+    when(templateRunnable.getDesignHandle()).thenReturn(templateHandle);
+    when(templateRunnable.getReportName()).thenReturn("sample.rptdesign");
+    when(templateHandle.copy()).thenReturn(copiedElement);
+    when(copiedElement.getHandle(null)).thenReturn(executionHandle);
+    when(reportEngine.openReportDesign(executionHandle)).thenReturn(executionRunnable);
+
+    executionFactory.createExecutionRunnable("sample", Locale.ENGLISH);
+
+    verify(executionHandle).setFileName("sample.rptdesign");
+    verify(templateHandle, never()).setFileName("sample.rptdesign");
+    verify(reportEngine, never()).openReportDesign(templateHandle);
+  }
+
+  @Test
+  @DisplayName("Should create independent execution copies")
+  void shouldCreateIndependentExecutionCopies() throws Exception {
+    IReportRunnable templateRunnable = mock(IReportRunnable.class);
+    IReportRunnable firstExecutionRunnable = mock(IReportRunnable.class);
+    IReportRunnable secondExecutionRunnable = mock(IReportRunnable.class);
+    ReportDesignHandle templateHandle = mock(ReportDesignHandle.class);
+    ReportDesignHandle firstExecutionHandle = mock(ReportDesignHandle.class);
+    ReportDesignHandle secondExecutionHandle = mock(ReportDesignHandle.class);
+    IDesignElement firstCopiedElement = mock(IDesignElement.class);
+    IDesignElement secondCopiedElement = mock(IDesignElement.class);
+
+    when(reportLoader.loadReport("sample", Locale.ENGLISH)).thenReturn(templateRunnable);
+    when(templateRunnable.getDesignHandle()).thenReturn(templateHandle);
+    when(templateRunnable.getReportName()).thenReturn("sample.rptdesign");
+    when(templateHandle.copy()).thenReturn(firstCopiedElement, secondCopiedElement);
+    when(firstCopiedElement.getHandle(null)).thenReturn(firstExecutionHandle);
+    when(secondCopiedElement.getHandle(null)).thenReturn(secondExecutionHandle);
+    when(reportEngine.openReportDesign(firstExecutionHandle)).thenReturn(firstExecutionRunnable);
+    when(reportEngine.openReportDesign(secondExecutionHandle)).thenReturn(secondExecutionRunnable);
+    when(firstExecutionRunnable.getDesignHandle()).thenReturn(firstExecutionHandle);
+    when(secondExecutionRunnable.getDesignHandle()).thenReturn(secondExecutionHandle);
+
+    IReportRunnable first = executionFactory.createExecutionRunnable("sample", Locale.ENGLISH);
+    IReportRunnable second = executionFactory.createExecutionRunnable("sample", Locale.ENGLISH);
+
+    assertNotSame(first, second);
+    assertNotSame(first.getDesignHandle(), second.getDesignHandle());
+    assertNotSame(templateHandle, first.getDesignHandle());
+    assertNotSame(templateHandle, second.getDesignHandle());
+  }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
@@ -48,7 +48,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class BirtReportingProcessServiceImplTest {
 
   @Mock private IReportEngine reportEngine;
-  @Mock private BirtReportLoader reportLoader;
+  @Mock private BirtReportExecutionFactory reportExecutionFactory;
   @Mock private BirtDataSourceConfigurer dataSourceConfigurer;
   @Mock private BirtParameterMapper parameterMapper;
   @Mock private BirtRenderer pdfRenderer;
@@ -128,7 +128,7 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
 
-    when(reportLoader.loadReport(anyString(), any())).thenReturn(design);
+    when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
     when(design.getDesignHandle()).thenReturn(designHandle);
     when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
 
@@ -163,7 +163,7 @@ class BirtReportingProcessServiceImplTest {
   @Test
   @DisplayName("Should throw when report file is not found")
   void shouldThrowWhenReportFileNotFound() {
-    when(reportLoader.loadReport(anyString(), any()))
+    when(reportExecutionFactory.createExecutionRunnable(anyString(), any()))
         .thenThrow(
             new PlatformDataIntegrityException(
                 "error.msg.reporting.report.not.found", "Report not found"));
@@ -183,17 +183,34 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
 
-    when(reportLoader.loadReport(anyString(), any())).thenReturn(design);
+    when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
     when(design.getDesignHandle()).thenReturn(designHandle);
     when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
     when(pdfRenderer.render(any(), anyString())).thenReturn(Response.ok().build());
 
     service.processRequest("sample", queryParams("PDF"));
 
-    verify(reportLoader).loadReport(eq("sample"), any());
+    verify(reportExecutionFactory).createExecutionRunnable(eq("sample"), any());
     verify(dataSourceConfigurer).configureAll(designHandle);
     verify(parameterMapper).applyParameters(eq(task), any());
     verify(pdfRenderer).render(eq(task), eq("sample"));
+  }
+
+  @Test
+  @DisplayName("Should close BIRT task after rendering")
+  void shouldCloseTaskAfterRendering() throws Exception {
+    IReportRunnable design = mock(IReportRunnable.class);
+    ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+    IRunAndRenderTask task = mock(IRunAndRenderTask.class);
+
+    when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+    when(design.getDesignHandle()).thenReturn(designHandle);
+    when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
+    when(pdfRenderer.render(any(), anyString())).thenReturn(Response.ok().build());
+
+    service.processRequest("sample", queryParams("PDF"));
+
+    verify(task).close();
   }
 
   private BirtRenderer getRendererForType(String outputType) {


### PR DESCRIPTION
## Summary

This PR addresses MX-287 by eliminating mutation of shared BIRT report design state during report execution.

Previously, the plugin cached `IReportRunnable` instances and then modified the underlying `ReportDesignHandle` with tenant-specific datasource properties before rendering. Since the same cached report instance could be reused across requests, this created a risk of shared mutable state and potential datasource leakage between concurrent report executions.

## Problem

Current execution flow:

```
loadReport()
  -> cached IReportRunnable
  -> getDesignHandle()
  -> mutate datasource properties
  -> createRunAndRenderTask()
  -> render
```

The cached runnable's design handle was being modified directly.

In BIRT 4.23, `createRunAndRenderTask()` does not automatically clone the underlying design model. As a result, concurrent executions could potentially operate on shared mutable datasource configuration.

## Solution

Introduced execution-local report creation.

New execution flow:

```
loadReport()
  -> cached template runnable
  -> copy ReportDesignHandle
  -> open execution-local runnable
  -> configure datasource
  -> create task
  -> render
```

Changes included:

* Added `BirtReportExecutionFactory`
* Created execution-local `IReportRunnable` instances from copied `ReportDesignHandle`s
* Updated `BirtReportingProcessServiceImpl` to use execution-local runnables
* Added explicit `IRunAndRenderTask.close()` cleanup
* Changed datasource configuration failures from silent logging to fail-fast behavior
* Added unit tests covering execution isolation

## Validation

### Unit Tests

Added:

* `BirtReportExecutionFactoryTest`
* Updated `BirtReportingProcessServiceImplTest`

Validation includes:

* Execution copies use independent design handles
* Cached template is not mutated
* Multiple execution copies remain isolated
* Tasks are closed after rendering

### Local Runtime Validation

Tested against a local Apache Fineract 1.12 deployment with the BIRT reporting plugin enabled.

Verified:

* Plugin startup successful
* Report generation successful
* HTML rendering successful
* Existing report functionality unchanged
* No datasource configuration errors observed
* Concurrent report executions complete successfully

## Caching Status

This PR does not introduce or modify cache implementation.

The goal of MX-287 is execution isolation.

The solution is intentionally designed so that if caching is enabled or improved in the future (e.g. Spring Cache, Caffeine, or other caching strategies), execution-level datasource isolation will already be guaranteed.

In other words:

```
Cached Template
      ↓
Execution Copy
      ↓
Datasource Injection
      ↓
Render
```

This architecture remains safe regardless of future cache optimizations.

## Scope

Included:

* Execution-local BIRT runnable creation
* Datasource isolation
* Task lifecycle cleanup
* Isolation-focused unit tests

Not included:

* Cache redesign
* Caffeine integration
* Custom ODA datasource implementation
* Report parameter refactoring
* Renderer changes
<img width="671" height="550" alt="Screenshot 2026-06-05 030019" src="https://github.com/user-attachments/assets/04caffe1-5581-462f-a565-7f8e3f9f30d6" />
<img width="916" height="313" alt="Screenshot 2026-06-05 040200" src="https://github.com/user-attachments/assets/f7372210-a992-412d-9253-afb77f980cb5" />
<img width="880" height="318" alt="Screenshot 2026-06-05 040228" src="https://github.com/user-attachments/assets/93021127-671c-4d7d-9ef7-83cd0540b7a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a factory to create isolated, per-execution report runnables ensuring each report run uses its own copy of the report design.
* **Bug Fixes**
  * Datasource configuration failures now surface as explicit errors instead of being silently logged.
  * Report execution closes BIRT tasks after rendering to improve stability and prevent resource leaks.
* **Tests**
  * Added and updated tests verifying runnable isolation and proper task closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->