### PR TITLE
MX-292 Improve BIRT report template cache behavior and lifecycle mana…

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactory.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportExecutionFactory.java
@@ -42,6 +42,8 @@ public class BirtReportExecutionFactory {
    */
   public IReportRunnable createExecutionRunnable(String reportName, Locale locale) {
     try {
+      reportLoader.validateTemplateFreshness(reportName, locale);
+
       IReportRunnable template = reportLoader.loadReport(reportName, locale);
       ReportDesignHandle templateHandle = (ReportDesignHandle) template.getDesignHandle();
 

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
@@ -7,12 +7,17 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
 import org.eclipse.birt.report.engine.api.IReportEngine;
 import org.eclipse.birt.report.engine.api.IReportRunnable;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
@@ -24,10 +29,11 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class BirtReportLoader {
-
   private final IReportEngine reportEngine;
   private final BirtPluginProperties birtProperties;
   private final ReportErrorHandler reportErrorHandler;
+  private final ConcurrentMap<String, Long> reportModificationTimes = new ConcurrentHashMap<>();
+  private final CacheManager cacheManager;
 
   private static final String DEFAULT_REPORTS_DIR =
       System.getProperty("user.home")
@@ -36,6 +42,8 @@ public class BirtReportLoader {
           + File.separator
           + "birtReports"
           + File.separator;
+  private static final String CACHE_KEY =
+      "#reportName + '_' + (#locale != null ? #locale.getLanguage() : 'en')";
 
   /**
    * Loads a BIRT report design with caching enabled.
@@ -44,16 +52,13 @@ public class BirtReportLoader {
    * @param locale the requested locale (can be null)
    * @return compiled IReportRunnable
    */
-  @Cacheable(
-      value = "birtReports",
-      key = "#reportName + '_' + (#locale != null ? #locale.getLanguage() : 'en')",
-      unless = "#result == null")
+  @Cacheable(value = "birtReports", key = CACHE_KEY, sync = true)
   public IReportRunnable loadReport(String reportName, java.util.Locale locale) {
 
     String reportPath = buildReportPath(reportName, locale);
 
     log.info(
-        "Loading BIRT report: {} (locale: {}) from path: {}",
+        "Cache miss for BIRT report: {} (locale: {}). Loading template from disk: {}",
         reportName,
         locale != null ? locale.getLanguage() : "en",
         reportPath);
@@ -87,6 +92,61 @@ public class BirtReportLoader {
     }
   }
 
+  public void validateTemplateFreshness(String reportName, java.util.Locale locale) {
+
+    String reportPath = buildReportPath(reportName, locale);
+    File reportFile = new File(reportPath);
+
+    if (!reportFile.exists()) {
+
+      evictCacheEntry(reportName, locale);
+
+      log.info("Report template no longer exists on disk. Evicted cached version: {}", reportName);
+
+      return;
+    }
+
+    String cacheKey = buildCacheKey(reportName, locale);
+
+    long currentLastModified = reportFile.lastModified();
+
+    Long cachedLastModified = reportModificationTimes.get(cacheKey);
+
+    if (cachedLastModified != null && !cachedLastModified.equals(currentLastModified)) {
+
+      log.info(
+          "Detected modification for report template: {} (locale: {}). Evicting cached version.",
+          reportName,
+          locale != null ? locale.getLanguage() : "en");
+
+      evictCacheEntry(reportName, locale);
+    }
+
+    reportModificationTimes.put(cacheKey, currentLastModified);
+  }
+
+  private String buildCacheKey(String reportName, java.util.Locale locale) {
+    return reportName + "_" + (locale != null ? locale.getLanguage() : "en");
+  }
+
+  private void evictCacheEntry(String reportName, java.util.Locale locale) {
+
+    String cacheKey = buildCacheKey(reportName, locale);
+
+    Cache cache = cacheManager.getCache("birtReports");
+
+    if (cache != null) {
+      cache.evict(cacheKey);
+    }
+
+    reportModificationTimes.remove(cacheKey);
+
+    log.info(
+        "Evicted cached BIRT report template: {} (locale: {})",
+        reportName,
+        locale != null ? locale.getLanguage() : "en");
+  }
+
   /** Builds the full path to the .rptdesign file, supporting locale-specific variants. */
   private String buildReportPath(String reportName, java.util.Locale locale) {
     String baseDir = getBaseReportsDirectory();
@@ -113,10 +173,19 @@ public class BirtReportLoader {
   }
 
   /**
-   * Optional: Method to clear cache for a specific report (useful during development or hot-reload)
+   * Evicts a specific report template from cache.
+   *
+   * <p>This allows updated report definitions to be reloaded from disk on the next request instead
+   * of continuing to use a cached template.
    */
+  @CacheEvict(value = "birtReports", key = CACHE_KEY)
   public void evictFromCache(String reportName, java.util.Locale locale) {
-    // Spring Cache abstraction - you can also use CacheManager directly if needed
-    log.info("Evicting report from cache: {} (locale: {})", reportName, locale);
+
+    reportModificationTimes.remove(buildCacheKey(reportName, locale));
+
+    log.info(
+        "Evicting BIRT report template from cache: {} (locale: {})",
+        reportName,
+        locale != null ? locale.getLanguage() : "en");
   }
 }


### PR DESCRIPTION
## Summary

This PR improves the BIRT report template caching implementation by addressing concurrency, cache invalidation, and cache observability concerns identified during the MX-292 investigation.

## Changes Implemented

### 1. Synchronized Cache Population

Updated BirtReportLoader caching configuration:

```java
@Cacheable(sync = true)
```

This ensures that when multiple requests simultaneously request the same uncached report template, only one thread performs the report loading and compilation process while other threads wait for the cached result.

### 2. Cache Eviction Support

Added explicit cache eviction support:

```java
@CacheEvict(...)
public void evictFromCache(...)
```

This provides a mechanism to invalidate cached report templates when updated report definitions need to be reloaded from disk.

### 3. Cache Observability

Added logging for:

* Cache misses
* Cache eviction events

These logs improve troubleshooting and help verify cache behavior during runtime.

## Validation

Testing confirmed:

* Report generation remains functional.
* Cache synchronization logic is correctly configured.
* Cache eviction support is available.
* Cache miss logging is generated as expected.

## Additional Findings

During investigation it was discovered that BIRT report caching is already integrated with Fineract's platform-wide cache infrastructure through the `birtReports` cache.

Further validation showed that the active cache implementation is determined by Fineract platform configuration through `RuntimeDelegatingCacheManager`.

When platform cache mode is configured as `NO_CACHE`, requests are delegated to `NoOpCache`. When configured as `SINGLE_NODE`, requests are delegated to EhCache.

This behavior is managed by the Fineract platform and is outside the scope of the reporting plugin.

## Issues Addressed

* Concurrent cache population risk
* Missing cache invalidation capability
* Limited cache visibility and diagnostics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BIRT report template caching by standardizing the cache key and synchronizing template loading to prevent duplicate loads.
  * Added template freshness tracking so cached templates are automatically evicted and reloaded when the on-disk template changes or is missing.
  * Updated cache eviction behavior and messaging to reflect disk-based loading and consistency.
  * Report execution now validates template freshness before each run to ensure the latest template is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->