### PR TITLE
MX-369 :Fix BIRT datasource driver resolution for Fineract RoutingDataSource

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/util/DataSourceUtils.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/util/DataSourceUtils.java
@@ -7,69 +7,103 @@
 package org.apache.fineract.infrastructure.report.util;
 
 import com.zaxxer.hikari.HikariDataSource;
+import java.lang.reflect.Method;
 import javax.sql.DataSource;
-import org.springframework.jdbc.datasource.DriverManagerDataSource; // fallback
 
-public class DataSourceUtils {
+public final class DataSourceUtils {
 
-  /**
-   * Extracts the JDBC driver class name from a DataSource. Works primarily with HikariDataSource
-   * (Fineract default).
-   */
+  private DataSourceUtils() {}
+
+  /** Extract JDBC driver class name from datasource. */
   public static String getDriverClassName(DataSource dataSource) {
+
     if (dataSource == null) {
       throw new IllegalArgumentException("DataSource cannot be null");
     }
 
-    // Primary path: HikariCP (most common in Spring Boot / Fineract)
+    // Handle Fineract RoutingDataSource and similar wrappers
+    DataSource target = unwrapRoutingDataSource(dataSource);
+
+    if (target != null && target != dataSource) {
+      return getDriverClassName(target);
+    }
+
+    // Direct Hikari datasource
     if (dataSource instanceof HikariDataSource hikari) {
+
       String driverClassName = hikari.getDriverClassName();
+
       if (driverClassName != null && !driverClassName.isBlank()) {
         return driverClassName;
       }
+
+      String jdbcUrl = hikari.getJdbcUrl();
+
+      if (jdbcUrl != null) {
+        return deriveDriverFromJdbcUrl(jdbcUrl);
+      }
     }
 
-    // Fallback 1: Spring's DriverManagerDataSource
-    if (dataSource instanceof DriverManagerDataSource dmds) {
-      return dmds.getClass().getName();
-    }
-
-    // Fallback 2: Try to unwrap (for proxies/wrappers)
+    // Generic datasource unwrap
     try {
+
       if (dataSource.isWrapperFor(HikariDataSource.class)) {
+
         HikariDataSource hikari = dataSource.unwrap(HikariDataSource.class);
-        return hikari.getDriverClassName();
+
+        String driverClassName = hikari.getDriverClassName();
+
+        if (driverClassName != null && !driverClassName.isBlank()) {
+          return driverClassName;
+        }
+
+        return deriveDriverFromJdbcUrl(hikari.getJdbcUrl());
       }
-      if (dataSource.isWrapperFor(DriverManagerDataSource.class)) {
-        DriverManagerDataSource dmds = dataSource.unwrap(DriverManagerDataSource.class);
-        return dmds.getClass().getName();
-      }
-    } catch (Exception e) {
-      // ignore unwrap failures
+
+    } catch (Exception ignored) {
     }
 
-    // Ultimate fallback: Try to derive from JDBC URL (less reliable but helpful)
-    String url = getJdbcUrl(dataSource);
-    if (url != null) {
-      if (url.startsWith("jdbc:postgresql")) {
-        return "org.postgresql.Driver";
-      } else if (url.startsWith("jdbc:mysql")) {
-        return "com.mysql.cj.jdbc.Driver";
-      } else if (url.startsWith("jdbc:mariadb")) {
-        return "org.mariadb.jdbc.Driver";
-      }
-      // Add more as needed
-    }
-
-    throw new IllegalStateException("Could not determine driver class name from DataSource");
+    throw new IllegalStateException(
+        "Could not determine driver class name from DataSource: "
+            + dataSource.getClass().getName());
   }
 
-  /** Helper to extract JDBC URL (useful for fallback). */
-  private static String getJdbcUrl(DataSource dataSource) {
-    if (dataSource instanceof HikariDataSource hikari) {
-      return hikari.getJdbcUrl();
+  private static DataSource unwrapRoutingDataSource(DataSource dataSource) {
+
+    try {
+
+      Method method = dataSource.getClass().getMethod("determineTargetDataSource");
+
+      Object target = method.invoke(dataSource);
+
+      if (target instanceof DataSource ds) {
+        return ds;
+      }
+
+    } catch (Exception ignored) {
     }
-    // Add other pool-specific getters if needed
+
     return null;
+  }
+
+  private static String deriveDriverFromJdbcUrl(String jdbcUrl) {
+
+    if (jdbcUrl == null || jdbcUrl.isBlank()) {
+      throw new IllegalStateException("Unable to determine driver class because JDBC URL is null");
+    }
+
+    if (jdbcUrl.startsWith("jdbc:postgresql")) {
+      return "org.postgresql.Driver";
+    }
+
+    if (jdbcUrl.startsWith("jdbc:mysql")) {
+      return "com.mysql.cj.jdbc.Driver";
+    }
+
+    if (jdbcUrl.startsWith("jdbc:mariadb")) {
+      return "org.mariadb.jdbc.Driver";
+    }
+
+    throw new IllegalStateException("Unsupported JDBC URL: " + jdbcUrl);
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes a compatibility issue between the Reporting Plugin and recent Apache Fineract datasource changes.

## Problem

The reporting plugin determines the JDBC driver by inspecting the injected `DataSource`.

Historically the datasource exposed to the plugin was a concrete datasource implementation (e.g. `HikariDataSource`), allowing the plugin to resolve the driver successfully.

Recent Apache Fineract changes introduced `RoutingDataSource`, which acts as a datasource proxy and delegates requests to tenant-specific datasources.

As a result, report generation started failing with:

```text
Could not determine driver class name from DataSource
```

Stacktrace:

```text
java.lang.IllegalStateException: Could not determine driver class name from DataSource
    at org.apache.fineract.infrastructure.report.util.DataSourceUtils.getDriverClassName(...)
```

The datasource exposed to the plugin was:

```text
org.apache.fineract.infrastructure.core.service.database.RoutingDataSource
```

instead of the underlying datasource implementation.

## Root Cause

`DataSourceUtils#getDriverClassName()` only supported direct datasource implementations such as `HikariDataSource`.

It was unable to resolve datasource wrappers introduced by newer Fineract versions.

## Solution

This PR introduces datasource unwrapping support before driver resolution.

Changes include:

* Added datasource wrapper detection using reflection
* Added support for resolving underlying datasources exposed through `determineTargetDataSource()`
* Added recursive datasource resolution
* Retained existing Hikari datasource handling
* Preserved backwards compatibility with older Fineract versions
* Avoided compile-time dependency on Fineract datasource internals

The implementation remains compatible across multiple Fineract releases.

## Verification

Before fix:

```text
Report generation failed:
Could not determine driver class name from DataSource
```

After fix:

```text
GET /runreports/Active_Loans_Details
HTTP 200 OK
```

The report is rendered successfully through the BIRT runtime.

## Testing Performed

* Built reporting plugin locally
* Loaded plugin into Docker-based Fineract deployment
* Verified plugin startup
* Verified BIRT engine initialization
* Executed Active_Loans_Details report
* Confirmed successful report rendering (HTTP 200)

## Additional Notes

This issue surfaced due to changes on the Apache Fineract side where datasource access now goes through `RoutingDataSource`. The fix ensures the reporting plugin remains compatible with both older and newer datasource implementations.
<img width="724" height="565" alt="Screenshot 2026-06-22 030110" src="https://github.com/user-attachments/assets/bf4967b0-ae24-4891-980e-d268a896a7e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved reliability and error messaging for database connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->