### PR TITLE
MX-299: Prepare BIRT report execution pipeline for future Fineract read-only datasource routing support.

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.birt.report.engine.api.IRunAndRenderTask;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -44,7 +45,15 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
   private final Map<String, BirtRenderer> birtRenderers;
   private final BirtPluginProperties birtProperties; // Injected
 
+  /**
+   * Report execution is read-only by nature.
+   *
+   * <p>This transaction boundary prepares the reporting subsystem for future datasource
+   * routing/read replica support in Fineract while also preventing accidental write operations
+   * during report generation.
+   */
   @Override
+  @Transactional(readOnly = true)
   public Response processRequest(String reportName, MultivaluedMap<String, String> queryParams) {
     String outputType = resolveOutputType(queryParams);
     Locale locale = ApiParameterHelper.extractLocale(queryParams);

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
@@ -43,6 +44,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("BirtReportingProcessServiceImpl Tests")
@@ -302,6 +304,21 @@ class BirtReportingProcessServiceImplTest {
             () -> service.processRequest("sample", queryParams("PDF")));
 
     assertEquals("error.msg.reporting.error", exception.getGlobalisationMessageCode());
+  }
+
+  @Test
+  @DisplayName("Should execute report processing in read-only transaction")
+  void shouldExecuteInReadOnlyTransaction() throws Exception {
+
+    Method method =
+        BirtReportingProcessServiceImpl.class.getMethod(
+            "processRequest", String.class, MultivaluedMap.class);
+
+    Transactional transactional = method.getAnnotation(Transactional.class);
+
+    assertNotNull(transactional);
+
+    assertTrue(transactional.readOnly());
   }
 
   private BirtRenderer getRendererForType(String outputType) {


### PR DESCRIPTION
## Summary

Prepare BIRT report execution for future read-only datasource routing support.

### Changes

* Added `@Transactional(readOnly = true)` to BIRT report execution entry point.
* Documented report execution as a read-only workload.
* Added unit test validating the transactional contract.

### Motivation

Current Fineract datasource infrastructure does not yet route read-only transactions to dedicated read replicas. However, report generation workloads are inherently read-only.

Introducing an explicit read-only transaction boundary prepares the reporting subsystem for future datasource routing enhancements while aligning report execution with Spring transaction best practices.

### Validation

* Existing report formats remain unchanged (PDF, XLS, XLSX, CSV, HTML).
* Unit tests pass.
* No functional behavior changes introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Report processing now runs within a read-only transaction, helping ensure safer and more consistent report execution.
* **Tests**
  * Added coverage to verify report processing uses the expected read-only transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->