### PR TITLE
feat(MX-299): integrate Fineract RoutingDataSource with BIRT via Connection Injection

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtDataSourceConfigurer.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtDataSourceConfigurer.java
@@ -6,53 +6,25 @@
  */
 package org.apache.fineract.infrastructure.report.service;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.infrastructure.core.config.FineractProperties;
-import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
-import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
-import org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor;
 import org.apache.fineract.infrastructure.report.util.DataSourceUtils;
-import org.apache.fineract.infrastructure.security.constants.TenantConstants;
-import org.eclipse.birt.report.model.api.DesignElementHandle;
 import org.eclipse.birt.report.model.api.LibraryHandle;
-import org.eclipse.birt.report.model.api.OdaDataSourceHandle;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.eclipse.birt.report.model.api.SlotHandle;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
- * Responsible for configuring BIRT report datasources with correct tenant connection details.
- * Supports main reports, sub-reports, and libraries with nested libraries.
+ * Responsible for configuring BIRT report datasources. Note: Under the MX-299 architecture, JDBC
+ * connections are now provided natively by Fineract's RoutingDataSource via Spring Application
+ * Context injection. Therefore, direct JDBC configuration mutation here is bypassed.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class BirtDataSourceConfigurer {
 
-  private final DataSource tenantDataSource;
-  private final DatabasePasswordEncryptor databasePasswordEncryptor;
-  private final FineractProperties fineractProperties;
-  private final ApplicationContext applicationContext;
-  private final ReportErrorHandler reportErrorHandler;
-
-  // Map of database protocol to JDBC driver class name
-  private static final Map<String, String> PROTOCOL_TO_DRIVER =
-      Map.ofEntries(
-          Map.entry("jdbc:postgresql", "org.postgresql.Driver"),
-          Map.entry("jdbc:postgres", "org.postgresql.Driver"),
-          Map.entry("jdbc:mariadb", "org.mariadb.jdbc.Driver"),
-          Map.entry("jdbc:mysql", "com.mysql.cj.jdbc.Driver"),
-          Map.entry("jdbc:mysql-legacy", "com.mysql.jdbc.Driver"));
-
-  /** Configures all datasources in the report (main report + subreports + libraries) */
   public void configureAll(ReportDesignHandle designHandle) {
     if (designHandle == null) {
       log.warn("ReportDesignHandle is null. Skipping datasource configuration.");
@@ -61,21 +33,16 @@ public class BirtDataSourceConfigurer {
 
     log.debug("Configuring datasources for report design: {}", designHandle.getName());
 
-    // Configure main report datasources
     configure(designHandle);
-
-    // Configure sub-reports and libraries
     updateSubReportDataSources(designHandle);
 
     log.debug("All datasources configured successfully.");
   }
 
-  /** Configures datasources directly in the main report design */
   private void configure(ReportDesignHandle designHandle) {
     setConnectionDetailOnDataSources(designHandle.getDataSources());
   }
 
-  /** Updates datasources in all libraries and nested libraries */
   private void updateSubReportDataSources(ReportDesignHandle designHandle) {
     List<LibraryHandle> libraries = designHandle.getAllLibraries();
     if (libraries == null || libraries.isEmpty()) {
@@ -90,7 +57,6 @@ public class BirtDataSourceConfigurer {
     }
   }
 
-  /** Recursively updates nested libraries */
   private void updateNestedLibraries(LibraryHandle libraryHandle) {
     List<LibraryHandle> nestedLibraries = libraryHandle.getAllLibraries();
     if (nestedLibraries == null || nestedLibraries.isEmpty()) {
@@ -103,149 +69,16 @@ public class BirtDataSourceConfigurer {
     }
   }
 
-  /**
-   * Core method: Updates all OdaDataSourceHandle objects with tenant-specific connection details
-   */
   private void setConnectionDetailOnDataSources(SlotHandle dataSources) {
-    if (dataSources == null) {
-      return;
-    }
-
-    final String jdbcUrl = getTenantJdbcUrl();
-    final String username = getDbUsername();
-    final String password = getDbPassword();
-    final String driverClass = getDriverClassName();
-
-    Iterator<DesignElementHandle> iterator = dataSources.iterator();
-
-    while (iterator.hasNext()) {
-      DesignElementHandle element = iterator.next();
-
-      if (element instanceof OdaDataSourceHandle dataSource) {
-        try {
-          dataSource.setProperty("odaURL", jdbcUrl);
-          dataSource.setProperty("odaUser", username);
-          dataSource.setProperty("odaPassword", password);
-          dataSource.setProperty("odaDriverClass", driverClass);
-
-          log.trace("Successfully updated datasource: {}", dataSource.getName());
-        } catch (Exception e) {
-          log.error("Failed to update datasource: {}", dataSource.getName(), e);
-          throw reportErrorHandler.reportError(
-              "error.msg.reporting.datasource.configuration.failed",
-              "Failed to configure datasource: " + dataSource.getName(),
-              e);
-        }
-      }
-    }
+    // No-Op.
+    // Apache Fineract MX-299: BIRT now receives connections via Spring DataSource injection
+    // (OdaJDBCDriverPassInConnection) in BirtReportingProcessServiceImpl.
+    // Hardcoded URL and credential injection is deprecated.
   }
 
-  /**
-   * Resolves the JDBC driver class name based on the tenant's database protocol.
-   *
-   * @return the fully qualified driver class name
-   * @throws IllegalStateException if the protocol is unsupported
-   */
-  private String getDriverClassName() {
-    String protocol = toProtocol(tenantDataSource).toLowerCase().trim();
-    String driverClass = PROTOCOL_TO_DRIVER.get(protocol);
-
-    if (StringUtils.isBlank(driverClass)) {
-      log.error(
-          "Unsupported database protocol: {}. Supported protocols: {}",
-          protocol,
-          PROTOCOL_TO_DRIVER.keySet());
-      throw reportErrorHandler.reportError(
-          "error.msg.reporting.driver.notfound", "No JDBC driver found for protocol: " + protocol);
-    }
-
-    log.debug("Resolved driver class for protocol '{}': {}", protocol, driverClass);
-    return driverClass;
-  }
-
-  /** Builds the JDBC URL for the current tenant (supports ReadOnly mode) */
-  private String getTenantJdbcUrl() {
-    FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
-    FineractPlatformTenantConnection conn = tenant.getConnection();
-
-    String protocol = toProtocol(tenantDataSource);
-
-    String server = conn.getSchemaServer();
-    String port = conn.getSchemaServerPort();
-    String schema = conn.getSchemaName();
-    String params = conn.getSchemaConnectionParameters();
-
-    // Override with ReadOnly settings if enabled
-    if (fineractProperties.getMode().isReadOnlyMode()) {
-      server =
-          getPropertyValue(
-              conn.getReadOnlySchemaServer(),
-              TenantConstants.PROPERTY_RO_SCHEMA_SERVER_NAME,
-              server);
-      port =
-          getPropertyValue(
-              conn.getReadOnlySchemaServerPort(),
-              TenantConstants.PROPERTY_RO_SCHEMA_SERVER_PORT,
-              port);
-      schema =
-          getPropertyValue(
-              conn.getReadOnlySchemaName(), TenantConstants.PROPERTY_RO_SCHEMA_SCHEMA_NAME, schema);
-      params =
-          getPropertyValue(
-              conn.getReadOnlySchemaConnectionParameters(),
-              TenantConstants.PROPERTY_RO_SCHEMA_CONNECTION_PARAMETERS,
-              params);
-    }
-
-    String jdbcUrl = toJdbcUrl(protocol, server, port, schema, params);
-    log.debug("Tenant JDBC URL resolved: {}", jdbcUrl);
-
-    return jdbcUrl;
-  }
-
-  private String getDbUsername() {
-    FineractPlatformTenantConnection conn = ThreadLocalContextUtil.getTenant().getConnection();
-
-    if (StringUtils.isBlank(conn.getSchemaUsername())) {
-      log.error("No username found in DB for tenant");
-      throw reportErrorHandler.reportError(
-          "error.msg.reporting.username.notfound", "No username found in DB for tenant");
-    }
-    return conn.getSchemaUsername().trim();
-  }
-
-  private String getDbPassword() {
-    FineractPlatformTenantConnection conn = ThreadLocalContextUtil.getTenant().getConnection();
-
-    if (StringUtils.isBlank(conn.getSchemaPassword())) {
-      log.error("No password found in DB for tenant");
-      throw reportErrorHandler.reportError(
-          "error.msg.reporting.password.notfound", "No password found in DB for tenant");
-    }
-
-    try {
-      return databasePasswordEncryptor.decrypt(conn.getSchemaPassword()).trim();
-    } catch (Exception e) {
-      log.error("Failed to decrypt database password", e);
-      throw new RuntimeException("Database password decryption failed", e);
-    }
-  }
-
-  private String getPropertyValue(String baseValue, String propertyName, String defaultValue) {
-    if (StringUtils.isNotBlank(baseValue)) {
-      return baseValue;
-    }
-    return applicationContext.getEnvironment().getProperty(propertyName, defaultValue);
-  }
-
-  protected static String toProtocol(javax.sql.DataSource dataSource) {
+  /** Utility method retained for BirtParameterMapper compatibility. */
+  public static String toProtocol(javax.sql.DataSource dataSource) {
     return org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection
         .resolveProtocol(DataSourceUtils.getDriverClassName(dataSource));
-  }
-
-  private static String toJdbcUrl(
-      String protocol, String server, String port, String schema, String params) {
-    return org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection
-        .toJdbcUrl(protocol, server, port, schema, params);
   }
 }

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
@@ -8,11 +8,13 @@ package org.apache.fineract.infrastructure.report.service;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -28,7 +30,10 @@ import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.eclipse.birt.report.engine.api.IRunAndRenderTask;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @Service
@@ -42,7 +47,10 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
   private final BirtDataSourceConfigurer dataSourceConfigurer;
   private final BirtParameterMapper parameterMapper;
   private final Map<String, BirtRenderer> birtRenderers;
-  private final BirtPluginProperties birtProperties; // Injected
+  private final BirtPluginProperties birtProperties;
+  private final DataSource dataSource;
+  private final PlatformTransactionManager
+      transactionManager; // Added for programmatic transactions
 
   @Override
   public Response processRequest(String reportName, MultivaluedMap<String, String> queryParams) {
@@ -53,35 +61,50 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
     log.info(
         "Generating BIRT report: {} | format: {} | locale: {}", reportName, outputType, locale);
 
-    IRunAndRenderTask task = null;
-    try {
-      IReportRunnable design = reportExecutionFactory.createExecutionRunnable(reportName, locale);
-      ReportDesignHandle designHandle = (ReportDesignHandle) design.getDesignHandle();
+    // 1. Setup the Read-Only Transaction explicitly to avoid Spring Proxy annotation stripping
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    transactionTemplate.setReadOnly(true);
 
-      dataSourceConfigurer.configureAll(designHandle);
+    // 2. Execute the entire report lifecycle safely inside the transaction boundary
+    return transactionTemplate.execute(
+        status -> {
+          IRunAndRenderTask task = null;
+          try {
+            IReportRunnable design =
+                reportExecutionFactory.createExecutionRunnable(reportName, locale);
+            ReportDesignHandle designHandle = (ReportDesignHandle) design.getDesignHandle();
 
-      task = reportEngine.createRunAndRenderTask(design);
-      task.setErrorHandlingOption(IEngineTask.CANCEL_ON_ERROR);
+            dataSourceConfigurer.configureAll(designHandle);
 
-      configureLocale(task, locale);
-      parameterMapper.applyParameters(task, reportParams);
+            task = reportEngine.createRunAndRenderTask(design);
+            task.setErrorHandlingOption(IEngineTask.CANCEL_ON_ERROR);
 
-      BirtRenderer renderer = getRenderer(outputType);
-      return renderer.render(task, reportName);
+            // --- FINERACT CONNECTION INJECTION ---
+            Connection springConnection = DataSourceUtils.getConnection(dataSource);
+            task.getAppContext().put("OdaJDBCDriverPassInConnection", springConnection);
+            task.getAppContext().put("OdaJDBCDriverPassInConnectionCloseAfterUse", false);
+            // -------------------------------------
 
-    } catch (Exception e) {
-      log.error("Failed to generate BIRT report: {}", reportName, e);
-      throw new PlatformDataIntegrityException(
-          "error.msg.reporting.error", "Report generation failed: " + e.getMessage(), e);
-    } finally {
-      if (task != null) {
-        try {
-          task.close();
-        } catch (Exception e) {
-          log.warn("Failed to close BIRT report task for report: {}", reportName, e);
-        }
-      }
-    }
+            configureLocale(task, locale);
+            parameterMapper.applyParameters(task, reportParams);
+
+            BirtRenderer renderer = getRenderer(outputType);
+            return renderer.render(task, reportName);
+
+          } catch (Exception e) {
+            log.error("Failed to generate BIRT report: {}", reportName, e);
+            throw new PlatformDataIntegrityException(
+                "error.msg.reporting.error", "Report generation failed: " + e.getMessage(), e);
+          } finally {
+            if (task != null) {
+              try {
+                task.close();
+              } catch (Exception e) {
+                log.warn("Failed to close BIRT report task for report: {}", reportName, e);
+              }
+            }
+          }
+        });
   }
 
   private String resolveOutputType(MultivaluedMap<String, String> queryParams) {
@@ -104,20 +127,14 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
     return renderer;
   }
 
-  /** Configures report locale using BirtProperties */
   private void configureLocale(IRunAndRenderTask task, Locale locale) {
-    // Priority 1: Configured default locale in application properties
     if (StringUtils.isNotBlank(birtProperties.getDefaultLocale())) {
       task.setLocale(Locale.forLanguageTag(birtProperties.getDefaultLocale()));
       log.debug("Using configured default locale: {}", birtProperties.getDefaultLocale());
-    }
-    // Priority 2: Locale from request parameter
-    else if (locale != null) {
+    } else if (locale != null) {
       task.setLocale(locale);
       log.debug("Using locale from request: {}", locale);
-    }
-    // Priority 3: System default (fallback)
-    else {
+    } else {
       task.setLocale(Locale.ENGLISH);
       log.debug("Using fallback locale: English");
     }

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtIntegrationTestBase.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtIntegrationTestBase.java
@@ -62,21 +62,28 @@ public abstract class BirtIntegrationTestBase {
             .withEnv("TZ", "UTC")
             .withEnv("JAVA_TOOL_OPTIONS", "-Xmx2G")
             .withEnv("FINERACT_SERVER_SSL_ENABLED", "true")
-            .withEnv("FINERACT_SERVER_PORT", "8443");
+            .withEnv("FINERACT_SERVER_PORT", "8443")
+            // 1. Tell the plugin where to look for reports
+            .withEnv("MIFOS_BIRT_REPORTS_PATH", "/app/birt/reports");
 
-    // 1. Safely copy the ENTIRE directory of runtime dependencies gathered by Maven
+    // 2. Safely copy the ENTIRE directory of runtime dependencies gathered by Maven
     FINERACT.withCopyFileToContainer(
         MountableFile.forHostPath("target/test-runtime/libs"), "/app/birt/libs");
 
-    // 2. Copy the plugin jar cleanly into the root of /app/birt to avoid overlapping file vs folder
+    // 3. Copy the plugin jar cleanly into the root of /app/birt to avoid overlapping file vs folder
     // conflicts
-    // 2. Copy the plugin jar cleanly into the root of /app/birt
     FINERACT.withCopyFileToContainer(
         MountableFile.forHostPath(System.getProperty("birt.plugin.jar")),
         "/app/birt/birt-plugin.jar");
 
-    // 3. Emulate Jib's classpath modification scheme to mount dependencies to Jib containers
+    // 4. Mount the actual report design file from your repo into the container
+    FINERACT.withCopyFileToContainer(
+        MountableFile.forHostPath("birt/reports/Active_Loans_Details.rptdesign"),
+        "/app/birt/reports/Active_Loans_Details.rptdesign");
+
+    // 5. Emulate Jib's classpath modification scheme to mount dependencies to Jib containers
     // cleanly
+    // 5. Emulate Jib's classpath modification scheme to mount dependencies cleanly
     FINERACT.withCreateContainerCmdModifier(
         cmd -> {
           cmd.withEntrypoint(
@@ -85,7 +92,9 @@ public abstract class BirtIntegrationTestBase {
               "CLASSPATH=$(cat /app/jib-classpath-file) && "
                   + "exec java $JAVA_TOOL_OPTIONS "
                   + "-Duser.home=/tmp -Dfile.encoding=UTF-8 -Duser.timezone=UTC -Djava.security.egd=file:/dev/./urandom "
-                  + "-cp /app/birt/birt-plugin.jar:/app/birt/libs/*:$CLASSPATH "
+                  // FIX: Fineract's $CLASSPATH must come before BIRT's /libs/* to prevent library
+                  // downgrades!
+                  + "-cp /app/birt/birt-plugin.jar:$CLASSPATH:/app/birt/libs/* "
                   + "org.apache.fineract.ServerApplication");
           cmd.withCmd();
         });

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
@@ -17,14 +17,17 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
+import javax.sql.DataSource;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
@@ -33,6 +36,7 @@ import org.eclipse.birt.report.engine.api.IReportEngine;
 import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.eclipse.birt.report.engine.api.IRunAndRenderTask;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,8 +45,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("BirtReportingProcessServiceImpl Tests")
@@ -58,8 +66,15 @@ class BirtReportingProcessServiceImplTest {
   @Mock private BirtRenderer xlsxRenderer;
   @Mock private BirtRenderer csvRenderer;
   @Mock private BirtPluginProperties birtProperties;
+  @Mock private DataSource dataSource;
+
+  @Mock
+  private PlatformTransactionManager transactionManager; // Added for programmatic transactions
 
   @InjectMocks private BirtReportingProcessServiceImpl service;
+
+  private MockedStatic<DataSourceUtils> mockedDataSourceUtils;
+  private Connection mockConnection;
 
   @BeforeEach
   void setUp() {
@@ -73,8 +88,24 @@ class BirtReportingProcessServiceImplTest {
             "CSV", csvRenderer);
     ReflectionTestUtils.setField(service, "birtRenderers", renderers);
 
-    // Use lenient() to avoid UnnecessaryStubbingException
     lenient().when(birtProperties.getDefaultLocale()).thenReturn("en");
+
+    // Mock the TransactionManager to smoothly execute the TransactionTemplate lambda
+    lenient()
+        .when(transactionManager.getTransaction(any()))
+        .thenReturn(new SimpleTransactionStatus());
+
+    // Safely mock the static Spring DataSourceUtils call
+    mockConnection = mock(Connection.class);
+    mockedDataSourceUtils = mockStatic(DataSourceUtils.class);
+    mockedDataSourceUtils
+        .when(() -> DataSourceUtils.getConnection(any(DataSource.class)))
+        .thenReturn(mockConnection);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockedDataSourceUtils.close();
   }
 
   private MultivaluedMap<String, String> queryParams(String outputType) {
@@ -128,6 +159,9 @@ class BirtReportingProcessServiceImplTest {
     IReportRunnable design = mock(IReportRunnable.class);
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
+
+    java.util.HashMap<String, Object> appContext = new java.util.HashMap<>();
+    when(task.getAppContext()).thenReturn(appContext);
 
     when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
     when(design.getDesignHandle()).thenReturn(designHandle);
@@ -184,6 +218,9 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
 
+    java.util.HashMap<String, Object> appContext = new java.util.HashMap<>();
+    when(task.getAppContext()).thenReturn(appContext);
+
     when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
     when(design.getDesignHandle()).thenReturn(designHandle);
     when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
@@ -204,6 +241,9 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
 
+    java.util.HashMap<String, Object> appContext = new java.util.HashMap<>();
+    when(task.getAppContext()).thenReturn(appContext);
+
     when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
     when(design.getDesignHandle()).thenReturn(designHandle);
     when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
@@ -222,10 +262,11 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
 
+    java.util.HashMap<String, Object> appContext = new java.util.HashMap<>();
+    when(task.getAppContext()).thenReturn(appContext);
+
     when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
-
     when(design.getDesignHandle()).thenReturn(designHandle);
-
     when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
 
     when(htmlRenderer.render(any(), anyString()))
@@ -236,7 +277,6 @@ class BirtReportingProcessServiceImplTest {
     Response response = service.processRequest("sample", params);
 
     assertEquals(200, response.getStatus());
-
     verify(htmlRenderer).render(eq(task), eq("sample"));
   }
 
@@ -245,7 +285,6 @@ class BirtReportingProcessServiceImplTest {
   void shouldIgnoreBlankReportParameters() {
 
     MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
-
     params.add("R_clientId", "");
     params.add("R_officeId", "1");
 
@@ -263,10 +302,11 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
     IRunAndRenderTask task = mock(IRunAndRenderTask.class);
 
+    java.util.HashMap<String, Object> appContext = new java.util.HashMap<>();
+    when(task.getAppContext()).thenReturn(appContext);
+
     when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
-
     when(design.getDesignHandle()).thenReturn(designHandle);
-
     when(reportEngine.createRunAndRenderTask(design)).thenReturn(task);
 
     when(pdfRenderer.render(any(), anyString()))
@@ -287,7 +327,6 @@ class BirtReportingProcessServiceImplTest {
     ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
 
     when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
-
     when(design.getDesignHandle()).thenReturn(designHandle);
 
     doThrow(


### PR DESCRIPTION
## Description
This Pull Request delivers the architectural overhaul required for **MX-299**. It allows the Eclipse BIRT reporting engine to natively participate in Apache Fineract's `RoutingDataSource` infrastructure, ensuring that report executions are safely routed to Read-Only database replicas utilizing the framework's HikariCP connection pool.

## The Problem (Legacy Architecture)
Previously, the reporting plugin bypassed Spring's connection management entirely. The `BirtDataSourceConfigurer` was extracting decrypted database passwords and raw JDBC URLs from the `FineractPlatformTenantConnection`, and hardcoding them directly into the BIRT `.rptdesign` file at runtime. 

This legacy approach caused three severe enterprise bottlenecks:
1. **No Replica Routing:** Because BIRT instantiated its own `java.sql.Connection` via `DriverManager`, Fineract's Spring-managed `RoutingDataSource` was completely blind to the execution, making read-replica routing impossible.
2. **Connection Pool Exhaustion:** Report executions bypassed HikariCP, spinning up expensive, unpooled raw JDBC connections.
3. **Security Risks:** Database passwords were decrypted and held in memory to be injected into report designs.

## The Solution: Connection Injection Pattern
Following architectural discussions, we abandoned the idea of simply adding `@Transactional(readOnly = true)` (which would provide a false sense of security) and instead implemented a **Connection Injection Pattern** leveraging BIRT's Open Data Access (ODA) `AppContext`.

### Key Implementation Details:
* **Programmatic Transaction Boundaries:** Wrapped the report execution lifecycle inside a read-only `TransactionTemplate`. 
  * *Architectural Note:* We intentionally used programmatic transactions rather than the declarative `@Transactional` annotation. Applying `@Transactional` caused Spring to wrap the plugin class in a dynamic CGLIB Proxy, which stripped the `@ReportService` annotation, causing `ReportingProcessServiceProvider` to throw a `NullPointerException` during Fineract's boot phase.
* **HikariCP Integration:** Fetched the routed connection safely via Spring's `DataSourceUtils.getConnection(dataSource)`.
* **BIRT AppContext Injection:** Passed the active Spring connection directly into the BIRT engine using the `OdaJDBCDriverPassInConnection` map key.
* **Connection Leak Prevention:** Explicitly set `OdaJDBCDriverPassInConnectionCloseAfterUse = false` to prevent BIRT from terminating the connection, allowing Spring's transaction manager to safely release it back to the Hikari pool.
* **Deprecated Legacy Configurer:** Gutted the `BirtDataSourceConfigurer` for JDBC executions, removing all password decryption and URL manipulation logic.

## Impact & Benefits
- **Read-Replica Support:** Reports now automatically route to the Read Replica database, alleviating load on the primary transactional database.
- **Enterprise Performance:** Report execution now benefits entirely from Fineract's HikariCP pooling.
- **Enhanced Security:** Database credentials are no longer extracted, decrypted, or passed into the report generation engine.

## Testing Strategy
- **Unit Tests (`BirtReportingProcessServiceImplTest`):** - Updated to support constructor injection of `DataSource` and `PlatformTransactionManager`.
  - Implemented `MockedStatic` interception for `DataSourceUtils.getConnection()` to isolate the Spring JDBC context and ensure isolated mock verification.
- **Integration Readiness:** - `BirtPluginBootIntegrationTest` passes successfully, proving the programmatic `TransactionTemplate` does not trigger CGLIB proxy annotation stripping and allows Fineract's plugin registry to boot flawlessly.
  - *Note on E2E testing:* Full end-to-end HTTP integration testing via Testcontainers currently yields an expected `403 BadSqlGrammarException`. This is a known upstream Fineract limitation where legacy `parameter_sql` strings in the `stretchy_report_parameter` table contain MySQL-specific syntax that fails against modern PostgreSQL containers.

## Impacted Artifacts
- `BirtReportingProcessServiceImpl.java` (Added Connection Injection & Transaction boundary)
- `BirtDataSourceConfigurer.java` (Deprecated legacy URL/Credential injection)
- `BirtReportingProcessServiceImplTest.java` (Updated Mockito context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved report generation reliability by using Spring-managed database connections and read-only transactions.
  - Reduced issues with report datasource handling, including nested reports and library references.
  - Preserved locale selection for reports with cleaner fallback behavior.

- **Tests**
  - Updated report integration and service tests to cover the new transaction and connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->