### PR TITLE
feat: Implement Pentaho PRPT Ingestion & XPath Parser (Phase 3 - PR 1/4)

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/model/PentahoParameter.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/model/PentahoParameter.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.model;
+
+/** Intermediate Representation (IR) of a Pentaho report parameter. */
+public record PentahoParameter(
+    String name,
+    String type,
+    boolean isMandatory,
+    String defaultValue,
+    boolean isList,
+    String queryName) {}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/model/PentahoReportModel.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/model/PentahoReportModel.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.model;
+
+import java.util.List;
+
+/** The Intermediate Representation (IR) of a complete Pentaho Report. */
+public record PentahoReportModel(
+    String reportName,
+    List<PentahoSqlDataset> datasets,
+    List<PentahoParameter> parameters,
+    List<PentahoReportModel> subreports) {}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/model/PentahoSqlDataset.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/model/PentahoSqlDataset.java
@@ -1,0 +1,9 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.model;
+
+public record PentahoSqlDataset(String queryName, String sqlQuery) {}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoArchiveMemoryLoader.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoArchiveMemoryLoader.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.parser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.springframework.stereotype.Component;
+
+/** MX-302: Extracts PRPT archives into a high-speed memory map. */
+@Component
+public class PentahoArchiveMemoryLoader {
+
+  // CodeRabbit: Made package-private so tests can dynamically reference them
+  static final int MAX_ENTRY_SIZE = 10 * 1024 * 1024; // 10 MiB limit per XML entry
+  static final int MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MiB limit for the entire archive
+  static final int MAX_ENTRIES = 1000; // Max 1000 file
+
+  /**
+   * Extracts all XML entries from a PRPT (ZIP) archive into an in-memory map, keyed by normalized
+   * entry path, enforcing per-entry, aggregate, and entry-count limits to mitigate zip-bomb risk.
+   *
+   * @param prptStream the archive stream; consumed and closed by this method
+   * @return a map of normalized XML entry path to its UTF-8 decoded content
+   * @throws IOException if reading the archive fails
+   * @throws PentahoMigrationException if archive limits are exceeded
+   */
+  public Map<String, String> loadArchive(InputStream prptStream) throws IOException {
+    Map<String, String> archiveContents = new HashMap<>();
+    int[] totalArchiveSize = new int[1]; // Array used to pass by reference for thread-safety
+    int entryCount = 0;
+
+    try (ZipInputStream zis = new ZipInputStream(prptStream)) {
+      ZipEntry entry;
+      while ((entry = zis.getNextEntry()) != null) {
+
+        entryCount++;
+        if (entryCount > MAX_ENTRIES) {
+          throw new PentahoMigrationException(
+              "PRPT archive exceeds maximum allowed entry count of " + MAX_ENTRIES);
+        }
+
+        if (!entry.isDirectory() && entry.getName().endsWith(".xml")) {
+          // CodeRabbit Fix: Normalize paths to prevent directory traversal / bypasses
+          String normalizedPath =
+              Paths.get(entry.getName()).normalize().toString().replace("\\", "/");
+          if (normalizedPath.startsWith("/")) {
+            normalizedPath = normalizedPath.substring(1);
+          }
+
+          archiveContents.put(normalizedPath, readEntryContent(zis, totalArchiveSize));
+        }
+        zis.closeEntry();
+      }
+    }
+    return archiveContents;
+  }
+
+  private String readEntryContent(ZipInputStream zis, int[] totalArchiveSize) throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    byte[] data = new byte[2048];
+    int entryBytes = 0;
+    int count;
+
+    while ((count = zis.read(data, 0, data.length)) != -1) {
+      entryBytes += count;
+      totalArchiveSize[0] += count;
+
+      if (entryBytes > MAX_ENTRY_SIZE) {
+        throw new PentahoMigrationException("PRPT XML entry exceeds maximum allowed size of 10MB.");
+      }
+      if (totalArchiveSize[0] > MAX_TOTAL_SIZE) {
+        throw new PentahoMigrationException(
+            "PRPT archive exceeds total aggregate size of 50MB to prevent multi-file Zip Bomb attacks.");
+      }
+
+      buffer.write(data, 0, count);
+    }
+    return buffer.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoMigrationException.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoMigrationException.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.parser;
+
+public class PentahoMigrationException extends RuntimeException {
+  public PentahoMigrationException(String message) {
+    super(message);
+  }
+
+  public PentahoMigrationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoPrptParser.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoPrptParser.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.parser;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoParameter;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoSqlDataset;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/** MX-303, MX-304, MX-305: Parses Pentaho XML schemas into Intermediate Representation (IR). */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PentahoPrptParser {
+
+  private final PentahoArchiveMemoryLoader memoryLoader;
+
+  /**
+   * Parses a Pentaho {@code .prpt} archive into the normalized {@link PentahoReportModel}.
+   *
+   * @param reportName name assigned to the resulting root report
+   * @param prptStream input stream containing the PRPT ZIP archive
+   * @return the parsed report model, including datasets, parameters, and subreports
+   * @throws PentahoMigrationException if the archive cannot be loaded or parsed
+   */
+  public PentahoReportModel parseReport(String reportName, InputStream prptStream) {
+    try {
+      Map<String, String> archive = memoryLoader.loadArchive(prptStream);
+      return parseRecursive(reportName, archive, "", new HashSet<>());
+    } catch (ParserConfigurationException
+        | SAXException
+        | IOException
+        | XPathExpressionException e) {
+      throw new PentahoMigrationException(
+          "Failed to parse Pentaho PRPT archive for report: " + reportName, e);
+    }
+  }
+
+  private PentahoReportModel parseRecursive(
+      String name, Map<String, String> archive, String basePath, Set<String> visitedPaths)
+      throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    if (!visitedPaths.add(basePath)) {
+      log.warn(
+          "Circular subreport reference detected at path: '{}'. Stopping recursion.", basePath);
+      return new PentahoReportModel(name, List.of(), List.of(), List.of());
+    }
+
+    log.debug("Parsing PRPT layer at base path: '{}'", basePath);
+
+    List<PentahoSqlDataset> datasets =
+        parseDatasets(archive.get(basePath + "datasources/sql-ds.xml"));
+    List<PentahoParameter> parameters =
+        parseParameters(archive.get(basePath + "datadefinition.xml"));
+    List<PentahoReportModel> subreports = parseSubreports(archive, basePath, visitedPaths);
+
+    return new PentahoReportModel(name, datasets, parameters, subreports);
+  }
+
+  // CodeRabbit Fix: DRY XML Node Set Evaluation
+  private NodeList evaluateNodeSet(String xml, String xpathExpr)
+      throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    Document doc = buildDocument(xml);
+    XPath xpath = XPathFactory.newInstance().newXPath();
+    return (NodeList) xpath.evaluate(xpathExpr, doc, XPathConstants.NODESET);
+  }
+
+  private List<PentahoSqlDataset> parseDatasets(String xml)
+      throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    List<PentahoSqlDataset> datasets = new ArrayList<>();
+    if (StringUtils.isBlank(xml)) return datasets;
+
+    NodeList queryNodes = evaluateNodeSet(xml, "//*[local-name()='query']");
+    XPath xpath = XPathFactory.newInstance().newXPath(); // For internal sub-queries
+
+    for (int i = 0; i < queryNodes.getLength(); i++) {
+      datasets.add(toSqlDataset((Element) queryNodes.item(i), xpath));
+    }
+    return datasets;
+  }
+
+  private PentahoSqlDataset toSqlDataset(Element queryElement, XPath xpath)
+      throws XPathExpressionException {
+    String queryName = queryElement.getAttribute("name");
+    // CodeRabbit Fix: Use string() to capture all text nodes and CDATA together
+    String sql = xpath.evaluate("string(./*[local-name()='static-query'])", queryElement);
+    return new PentahoSqlDataset(queryName, sql.trim());
+  }
+
+  private List<PentahoParameter> parseParameters(String xml)
+      throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    List<PentahoParameter> parameters = new ArrayList<>();
+    if (StringUtils.isBlank(xml)) return parameters;
+
+    NodeList paramNodes =
+        evaluateNodeSet(
+            xml, "//*[local-name()='plain-parameter' or local-name()='list-parameter']");
+    for (int i = 0; i < paramNodes.getLength(); i++) {
+      parameters.add(toParameter((Element) paramNodes.item(i)));
+    }
+    return parameters;
+  }
+
+  private PentahoParameter toParameter(Element paramElement) {
+    String name = paramElement.getAttribute("name");
+    String type = paramElement.getAttribute("type");
+    boolean mandatory = "true".equalsIgnoreCase(paramElement.getAttribute("mandatory"));
+    String defaultValue = paramElement.getAttribute("default-value");
+    boolean isList = paramElement.getNodeName().endsWith("list-parameter");
+    String queryName = isList ? paramElement.getAttribute("query") : null;
+    return new PentahoParameter(name, type, mandatory, defaultValue, isList, queryName);
+  }
+
+  private List<PentahoReportModel> parseSubreports(
+      Map<String, String> archive, String basePath, Set<String> visitedPaths)
+      throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    List<PentahoReportModel> subreports = new ArrayList<>();
+    String layoutXml = archive.get(basePath + "layout.xml");
+    if (StringUtils.isBlank(layoutXml)) return subreports;
+
+    NodeList subreportNodes = evaluateNodeSet(layoutXml, "//*[local-name()='sub-report']");
+    for (int i = 0; i < subreportNodes.getLength(); i++) {
+      // CodeRabbit Fix: Safely unwrap Optional
+      toSubreport((Element) subreportNodes.item(i), i, archive, basePath, visitedPaths)
+          .ifPresent(subreports::add);
+    }
+    return subreports;
+  }
+
+  private Optional<PentahoReportModel> toSubreport(
+      Element subElement,
+      int index,
+      Map<String, String> archive,
+      String basePath,
+      Set<String> visitedPaths)
+      throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    String href = subElement.getAttribute("href");
+    if (StringUtils.isBlank(href)) return Optional.empty();
+
+    String cleanHref = href.startsWith("/") ? href.substring(1) : href;
+    int slashIdx = cleanHref.lastIndexOf("/");
+
+    if (slashIdx < 0) {
+      log.warn("Skipping subreport href without directory: '{}'", href);
+      return Optional.empty();
+    }
+
+    // CodeRabbit Fix: Safely normalize directory traversal to correctly identify circular paths
+    String targetDir = cleanHref.substring(0, slashIdx + 1);
+    String newBasePath = Paths.get(basePath, targetDir).normalize().toString().replace("\\", "/");
+    if (!newBasePath.isEmpty() && !newBasePath.endsWith("/")) {
+      newBasePath += "/"; // Retain trailing slash for directory mapping
+    }
+
+    if (newBasePath.equals(basePath)) {
+      log.warn("Skipping self-referencing subreport href: '{}'", href);
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        parseRecursive("Subreport_" + index, archive, newBasePath, new HashSet<>(visitedPaths)));
+  }
+
+  private Document buildDocument(String xml)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+
+    try {
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    } catch (IllegalArgumentException e) {
+      log.debug(
+          "JAXP properties ACCESS_EXTERNAL_DTD/SCHEMA not supported by the underlying XML parser. Ignoring.");
+    }
+
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    return builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoArchiveMemoryLoaderTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoArchiveMemoryLoaderTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PentahoArchiveMemoryLoader TDD Tests")
+class PentahoArchiveMemoryLoaderTest {
+
+  private final PentahoArchiveMemoryLoader loader = new PentahoArchiveMemoryLoader();
+
+  private InputStream createZipArchive(Map<String, String> entries) throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+      for (Map.Entry<String, String> entry : entries.entrySet()) {
+        zos.putNextEntry(new ZipEntry(entry.getKey()));
+        // CodeRabbit Fix: Specify UTF-8 to ensure deterministic behavior
+        zos.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+        zos.closeEntry();
+      }
+    }
+    return new ByteArrayInputStream(baos.toByteArray());
+  }
+
+  @Test
+  @DisplayName("Should successfully load and normalize XML entries")
+  void shouldLoadAndNormalizeEntries() throws Exception {
+    Map<String, String> mockFiles =
+        Map.of(
+            "layout.xml", "<layout/>",
+            "nested/../datadefinition.xml", "<data/>", // Tests normalization
+            "image.png", "binary_data" // Should be ignored
+            );
+
+    InputStream zipStream = createZipArchive(mockFiles);
+    Map<String, String> archive = loader.loadArchive(zipStream);
+
+    assertThat(archive).hasSize(2);
+    assertThat(archive).containsEntry("layout.xml", "<layout/>");
+    assertThat(archive).containsEntry("datadefinition.xml", "<data/>");
+  }
+
+  @Test
+  @DisplayName("Should throw exception when archive contains too many entries")
+  void shouldThrowWhenTooManyEntries() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+      // CodeRabbit Fix: Dynamically reference the limit
+      for (int i = 0; i < PentahoArchiveMemoryLoader.MAX_ENTRIES + 5; i++) {
+        zos.putNextEntry(new ZipEntry("file" + i + ".xml"));
+        zos.write("<xml/>".getBytes(StandardCharsets.UTF_8));
+        zos.closeEntry();
+      }
+    }
+
+    InputStream zipStream = new ByteArrayInputStream(baos.toByteArray());
+
+    assertThatThrownBy(() -> loader.loadArchive(zipStream))
+        .isInstanceOf(PentahoMigrationException.class)
+        .hasMessageContaining("maximum allowed entry count");
+  }
+
+  @Test
+  @DisplayName("Should throw exception when a single entry exceeds maximum size")
+  void shouldThrowWhenEntryExceedsMaxSize() throws Exception {
+    StringBuilder largeContent = new StringBuilder();
+    largeContent.append("<xml>".repeat(2_500_000)); // ~12.5MB
+    InputStream zipStream = createZipArchive(Map.of("big.xml", largeContent.toString()));
+
+    assertThatThrownBy(() -> loader.loadArchive(zipStream))
+        .isInstanceOf(PentahoMigrationException.class)
+        .hasMessageContaining("maximum allowed size of 10MB");
+  }
+
+  @Test
+  @DisplayName("Should throw exception when total archive exceeds aggregate size")
+  void shouldThrowWhenTotalExceedsMaxSize() throws Exception {
+    // Create multiple entries whose combined size exceeds 50MB
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+      for (int i = 0; i < 6; i++) {
+        zos.putNextEntry(new ZipEntry("file" + i + ".xml"));
+        zos.write(new byte[9 * 1024 * 1024]); // 9MB each, 54MB total
+        zos.closeEntry();
+      }
+    }
+    InputStream zipStream = new ByteArrayInputStream(baos.toByteArray());
+
+    assertThatThrownBy(() -> loader.loadArchive(zipStream))
+        .isInstanceOf(PentahoMigrationException.class)
+        .hasMessageContaining("total aggregate size of 50MB");
+  }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoPrptParserTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/parser/PentahoPrptParserTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PentahoPrptParser TDD Tests")
+class PentahoPrptParserTest {
+
+  @Mock private PentahoArchiveMemoryLoader memoryLoader;
+
+  @InjectMocks private PentahoPrptParser parser;
+
+  @Test
+  @DisplayName("Should successfully parse Pentaho datasets, parameters, and recursive subreports")
+  void shouldParsePentahoReportModelSuccessfully() throws Exception {
+    Map<String, String> mockArchive = new HashMap<>();
+
+    String sqlXml =
+        "<data:sql-datasource xmlns:data=\"http://jfreereport.sourceforge.net/namespaces/datasources/sql\">"
+            + "<data:query-definitions><data:query name=\"Branch\"><data:static-query>select id from m_office</data:static-query></data:query></data:query-definitions></data:sql-datasource>";
+
+    String paramXml =
+        "<data-definition><parameter-definition><plain-parameter name=\"tenantUrl\" mandatory=\"true\" type=\"java.lang.String\" default-value=\"jdbc\"/></parameter-definition></data-definition>";
+
+    String layoutXml =
+        "<layout><report-footer><sub-report href=\"/subreport/content.xml\"/></report-footer></layout>";
+
+    mockArchive.put("datasources/sql-ds.xml", sqlXml);
+    mockArchive.put("datadefinition.xml", paramXml);
+    mockArchive.put("layout.xml", layoutXml);
+    mockArchive.put("subreport/datasources/sql-ds.xml", sqlXml);
+
+    when(memoryLoader.loadArchive(any())).thenReturn(mockArchive);
+
+    PentahoReportModel result =
+        parser.parseReport("TestReport", new ByteArrayInputStream(new byte[0]));
+
+    assertThat(result).isNotNull();
+    assertThat(result.reportName()).isEqualTo("TestReport");
+
+    assertThat(result.datasets()).hasSize(1);
+    assertThat(result.datasets().get(0).queryName()).isEqualTo("Branch");
+    assertThat(result.datasets().get(0).sqlQuery()).isEqualTo("select id from m_office");
+
+    assertThat(result.parameters()).hasSize(1);
+    assertThat(result.parameters().get(0).name()).isEqualTo("tenantUrl");
+    assertThat(result.parameters().get(0).isMandatory()).isTrue();
+    // CodeRabbit Fix: Assert type and default-value
+    assertThat(result.parameters().get(0).type()).isEqualTo("java.lang.String");
+    assertThat(result.parameters().get(0).defaultValue()).isEqualTo("jdbc");
+
+    assertThat(result.subreports()).hasSize(1);
+    assertThat(result.subreports().get(0).reportName()).isEqualTo("Subreport_0");
+    assertThat(result.subreports().get(0).datasets().get(0).queryName()).isEqualTo("Branch");
+  }
+
+  @Test
+  @DisplayName("Should parse list-parameter with query reference")
+  void shouldParseListParameter() throws Exception {
+    Map<String, String> mockArchive = new HashMap<>();
+    String paramXml =
+        "<data-definition><parameter-definition>"
+            + "<list-parameter name=\"officeList\" mandatory=\"false\" type=\"java.lang.String\" "
+            + "default-value=\"\" query=\"BranchQuery\"/>"
+            + "</parameter-definition></data-definition>";
+
+    mockArchive.put("datadefinition.xml", paramXml);
+    when(memoryLoader.loadArchive(any())).thenReturn(mockArchive);
+
+    PentahoReportModel result =
+        parser.parseReport("TestReport", new ByteArrayInputStream(new byte[0]));
+
+    assertThat(result.parameters()).hasSize(1);
+    assertThat(result.parameters().get(0).name()).isEqualTo("officeList");
+    assertThat(result.parameters().get(0).isList()).isTrue();
+    assertThat(result.parameters().get(0).queryName()).isEqualTo("BranchQuery");
+    assertThat(result.parameters().get(0).isMandatory()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should gracefully skip circular subreports to prevent infinite loops")
+  void shouldSkipCircularSubreports() throws Exception {
+    Map<String, String> mockArchive = new HashMap<>();
+
+    // Create a genuine circular loop by routing down into a folder,
+    // then using '../' to route right back up to the parent.
+    String parentLayoutXml =
+        "<layout><report-footer><sub-report href=\"/child/content.xml\"/></report-footer></layout>";
+    String childLayoutXml =
+        "<layout><report-footer><sub-report href=\"../content.xml\"/></report-footer></layout>";
+
+    mockArchive.put("layout.xml", parentLayoutXml);
+    mockArchive.put("child/layout.xml", childLayoutXml);
+
+    when(memoryLoader.loadArchive(any())).thenReturn(mockArchive);
+    PentahoReportModel result =
+        parser.parseReport("TestReport", new ByteArrayInputStream(new byte[0]));
+
+    // The parent successfully loads the child
+    assertThat(result.subreports()).hasSize(1);
+
+    PentahoReportModel child = result.subreports().get(0);
+
+    // The child tries to load the parent, hits the circular guard, and gets an empty dummy model
+    // back
+    assertThat(child.subreports()).hasSize(1);
+
+    // Verify the blocked circular reference is an empty shell to stop recursion!
+    PentahoReportModel blockedCircularRef = child.subreports().get(0);
+    assertThat(blockedCircularRef.datasets()).isEmpty();
+    assertThat(blockedCircularRef.parameters()).isEmpty();
+    assertThat(blockedCircularRef.subreports()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should skip malformed subreport hrefs")
+  void shouldSkipInvalidHrefs() throws Exception {
+    Map<String, String> mockArchive = new HashMap<>();
+    String badLayoutXml =
+        "<layout><report-footer><sub-report href=\"badcontentxml\"/></report-footer></layout>";
+    mockArchive.put("layout.xml", badLayoutXml);
+
+    when(memoryLoader.loadArchive(any())).thenReturn(mockArchive);
+    PentahoReportModel result =
+        parser.parseReport("TestReport", new ByteArrayInputStream(new byte[0]));
+
+    assertThat(result.subreports()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should wrap parsing exceptions inside PentahoMigrationException")
+  void shouldWrapExceptions() throws Exception {
+    when(memoryLoader.loadArchive(any())).thenThrow(new IOException("Simulated IO Error"));
+
+    assertThatThrownBy(
+            () -> parser.parseReport("TestReport", new ByteArrayInputStream(new byte[0])))
+        .isInstanceOf(PentahoMigrationException.class)
+        .hasMessageContaining("Failed to parse Pentaho PRPT archive for report: TestReport")
+        .hasCauseInstanceOf(IOException.class);
+  }
+}


### PR DESCRIPTION
## 📝 Overview
This PR represents the first foundational phase of the Machine-to-Machine (M2M) Migration Compiler (**Phase 3**). It implements the ingestion layer responsible for reading legacy Pentaho `.prpt` archives into memory and extracting their underlying XML schemas into a normalized Intermediate Representation (IR).

**Resolves:**
* **MX-302:** Implement PRPT Archive Parsing Infrastructure
* **MX-303:** Parse Pentaho SQL Dataset Definitions
* **MX-304:** Parse Pentaho Parameter Metadata
* **MX-305:** Parse Pentaho Layout & Report Structure Metadata

## 🏗️ Architectural Changes
* **Intermediate Representation (IR):** Introduced `PentahoReportModel`, `PentahoSqlDataset`, and `PentahoParameter` as clean Java records. This isolates the legacy XML bloat from the rest of the compiler pipeline.
* **In-Memory Archive Extraction (`PentahoArchiveMemoryLoader`):** Built a high-speed utility using standard `ZipInputStream` to unzip `.prpt` archives and load their internal XML files into a `Map<String, String>`. This completely prevents disk I/O bottlenecks during mass migrations.
* **Surgical XPath Parsing (`PentahoPrptParser`):** 
  * Utilizes `javax.xml.xpath` to dynamically bypass verbose namespaces (e.g., `<data:sql-datasource>`).
  * Recursively crawls the archive map when it encounters `<sub-report>` nodes in `layout.xml`, accurately mirroring Pentaho's nested report architecture into child `PentahoReportModel` instances.

## 🧪 Testing Strategy
* **`PentahoPrptParserTest`:** Mocked the `PentahoArchiveMemoryLoader` to feed raw string representations of `sql-ds.xml`, `datadefinition.xml`, and `layout.xml` directly into the parser. 
* Validates dataset mappings, parameter typings, and verifies that the recursion accurately traverses simulated sub-directories (`subreport/content.xml`). 
* Code compiles cleanly and passes all checkstyle rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing Pentaho PRPT report archives into an immutable report model with datasets, parameters, and nested subreports.
  * Improved robustness by detecting and skipping circular subreport references and ignoring malformed subreport links.
  * Added safer archive/XML handling with size/entry limits and hardened XML parsing.
* **Tests**
  * Added automated test coverage for PRPT parsing, including datasets/parameters/subreports, circular/invalid subreport handling, exception wrapping, and in-memory archive loading/entry normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->