### PR TITLE
GAZ-306: Fix Pentaho reports connecting to the wrong / no tenant database 

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor;
+import org.apache.fineract.infrastructure.core.service.database.RoutingDataSource;
 import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 import org.apache.fineract.infrastructure.report.annotation.ReportService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
@@ -91,7 +92,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
   @Autowired
   public PentahoReportingProcessServiceImpl(
       final PlatformSecurityContext context,
-      final @Qualifier("hikariTenantDataSource") DataSource tenantDataSource,
+      final RoutingDataSource tenantDataSource,
       DatabasePasswordEncryptor databasePasswordEncryptor) {
     ClassicEngineBoot.getInstance().start();
     this.tenantDataSource = tenantDataSource;
@@ -173,7 +174,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
 
       // Override Data Connection Factory with the driver and url
       CompoundDataFactory compoundDataFactory = (CompoundDataFactory) masterReport.getDataFactory();
-      setConnectionDetail(compoundDataFactory.get(0));
+      setConnectionDetail(compoundDataFactory.getReference(0));
 
       final var reportEnvironment = (DefaultReportEnvironment) masterReport.getReportEnvironment();
       if (locale != null) {
@@ -186,7 +187,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
       for (SubReport subReport : subReports) {
         CompoundDataFactory subReportCompoundDataFactory =
             (CompoundDataFactory) subReport.getDataFactory();
-        setConnectionDetail(subReportCompoundDataFactory.get(0));
+        setConnectionDetail(subReportCompoundDataFactory.getReference(0));
       }
 
       final var baos = new ByteArrayOutputStream();
@@ -423,7 +424,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
     @Override
     public Object getConnectionHash() {
       // Using hashcode to identify unique data sources for Pentaho's internal caching
-      return dataSource.hashCode();
+      return dataSource.hashCode() + "@" + ThreadLocalContextUtil.getTenant().getTenantIdentifier();
     }
   }
 }


### PR DESCRIPTION
## Problem

Pentaho report generation did not connect to the requesting tenant's database.
Depending on the deployment, reports either failed (e.g. `relation "m_office"
does not exist`, or a
 connection error to the template's embedded DB host) or worse, silently returned another tenant's data.

Three issues in `PentahoReportingProcessServiceImpl` caused this:

1. **The connection-provider override never took effect.** It was applied to
   `compoundDataFactory.get(0)`, but `CompoundDataFactory.get(int)` returns a
   `derive()` *copy*, so the override mutated a throwaway and the report used
   the connection embedded in the `.prpt` template.
2. **Wrong datasource.** The provider used the `hikariTenantDataSource` bean
   the `fineract_tenants` registry DB, which has no business tables causing
   `relation "..." does not exist`.
3. **Cross-tenant cache collision.** `getConnectionHash()` returned
   `dataSource.hashCode()`, identical for every tenant (the datasource is a
   single shared bean). Pentaho's data cache keyed on it and served the first
   tenant's results to all subsequent tenants.

## Solution

Three small changes (+1 import) in `PentahoReportingProcessServiceImpl`:

1. Use `getReference(0)` instead of `get(0)` (main report + sub-reports) so the
   connection-provider override mutates the live data factory.
2. Inject the per-tenant `RoutingDataSource` instead of `hikariTenantDataSource`,
   so the report queries the current tenant's own database.
3. Include the tenant identifier in `getConnectionHash()` so each tenant gets a
   distinct cache key.

## Testing

Verified on Fineract 1.14.0 + PostgreSQL with three tenants
(greenbank / bluebank / redbank):

- Each tenant's report renders its own data (confirmed distinct clients per
  tenant), not a shared/first-tenant result.
- Both HTML and PDF output render successfully.
