### PR TITLE
GAZ-306: Fix Pentaho reports not connecting to the requesting tenant's database

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
@@ -189,7 +189,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
 
       // Override Data Connection Factory with the driver and url
       CompoundDataFactory compoundDataFactory = (CompoundDataFactory) masterReport.getDataFactory();
-      setConnectionDetail(compoundDataFactory.get(0));
+      setConnectionDetail(compoundDataFactory.getReference(0));
 
       final var reportEnvironment = (DefaultReportEnvironment) masterReport.getReportEnvironment();
 
@@ -207,7 +207,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
       for (SubReport subReport : subReports) {
         CompoundDataFactory subReportCompoundDataFactory =
             (CompoundDataFactory) subReport.getDataFactory();
-        setConnectionDetail(subReportCompoundDataFactory.get(0));
+        setConnectionDetail(subReportCompoundDataFactory.getReference(0));
       }
 
       final var baos = new ByteArrayOutputStream();

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/PentahoReportsTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/PentahoReportsTest.java
@@ -15,6 +15,8 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import com.google.common.truth.Truth;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
@@ -43,7 +45,7 @@ public class PentahoReportsTest {
   void runExpectedPaymentsPentahoReport() {
     ResponseBody r =
         ok(
-            fineract()
+            fineract("default")
                 .reportsRun
                 .runReportGetFile(
                     "Expected Payments By Date - Formatted",
@@ -67,29 +69,74 @@ public class PentahoReportsTest {
     Truth.assertThat(r.contentType()).isEqualTo(MediaType.get("application/pdf"));
   }
 
+  /**
+   * Verifies that a report is generated against the *requesting* tenant's database. The same report
+   * is run for two different tenants; each must return that tenant's own data, so the (data) output
+   * differs. Before the connection fix, {@code setConnectionDetail} was applied to a {@code
+   * derive()} copy of the data factory, so both tenants received the first/embedded tenant's data
+   * (identical output).
+   *
+   * <p>Requires the target Fineract to have two tenants with distinct client data. Override the
+   * tenant identifiers with {@code -Dfineract.it.tenantA} / {@code -Dfineract.it.tenantB}.
+   */
+  @Test
+  void reportUsesRequestingTenantDatabase() {
+    String tenantA = System.getProperty("fineract.it.tenantA", "greenbank");
+    String tenantB = System.getProperty("fineract.it.tenantB", "bluebank");
+
+    String reportA = tenantData(runClientListing(tenantA));
+    String reportB = tenantData(runClientListing(tenantB));
+
+    Truth.assertThat(reportA).isNotEmpty();
+    Truth.assertThat(reportB).isNotEmpty();
+    Truth.assertThat(reportA).isNotEqualTo(reportB);
+  }
+
+  private String runClientListing(String tenant) {
+    ResponseBody r =
+        ok(
+            fineract(tenant)
+                .reportsRun
+                .runReportGetFile(
+                    "Client Listing(Pentaho)",
+                    Map.of(
+                        "tenantIdentifier", tenant,
+                        "locale", "en",
+                        "R_selectOffice", "1",
+                        "output-type", "HTML")));
+    try {
+      return r.string();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  // Strips HTML tags and the report's generation-time footer ("On: <date>") so the comparison
+  // reflects the tenant's data rather than the timestamp (which always differs between runs).
+  private static String tenantData(String html) {
+    return html.replaceAll("<[^>]+>", " ")
+        .replaceAll("(?s)On:.*", "")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
   // ---
   // copy/paste from
   // fineract/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/IntegrationTest.java
   // TODO move that from src/test to src/main publish an artifact, after
   // https://issues.apache.org/jira/browse/FINERACT-1102
 
-  private FineractClient fineract;
-
-  protected FineractClient fineract() {
-    if (fineract == null) {
-      String url =
-          System.getProperty("fineract.it.url", "https://localhost:8443/fineract-provider/api/v1/");
-      // insecure(true) should *ONLY* ever be used for https://localhost:8443, NOT in real clients!!
-      fineract =
-          FineractClient.builder()
-              .insecure(true)
-              .baseURL(url)
-              .tenant("default")
-              .basicAuth("mifos", "password")
-              .logging(Level.NONE)
-              .build();
-    }
-    return fineract;
+  protected FineractClient fineract(String tenant) {
+    String url =
+        System.getProperty("fineract.it.url", "https://localhost:8443/fineract-provider/api/v1/");
+    // insecure(true) should *ONLY* ever be used for https://localhost:8443, NOT in real clients!!
+    return FineractClient.builder()
+        .insecure(true)
+        .baseURL(url)
+        .tenant(tenant)
+        .basicAuth("mifos", "password")
+        .logging(Level.NONE)
+        .build();
   }
 
   protected <T> T ok(Call<T> call) {


### PR DESCRIPTION
## Problem

Pentaho reports did not connect to the requesting tenant's database. Depending on the 
deployment, reports either failed (e.g. a connection error / "Failed to execute query") or 
silently returned another tenant's data.

**Root cause:** `setConnectionDetail(...)` is called on `compoundDataFactory.get(0)`, but 
`CompoundDataFactory.get(int)` returns a `derive()` *copy*. The per-tenant connection 
(URL + credentials built from the tenant connection) is applied to that throwaway copy, so at 
query time the report uses the connection embedded in the `.prpt` template instead of the
requesting tenant's own database.

## Solution

Use `getReference(0)` instead of `get(0)` (main report + sub-reports) so the connection override 
mutates the live data factory the engine actually queries with. 

## Testing


- On Fineract 1.14.0 + PostgreSQL, applying the `getReference` fix made
  per-tenant reports render correctly: greenbank / bluebank / redbank each
  render their own data (distinct clients per tenant), in HTML and PDF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pentaho report generation by ensuring the correct data connection is used for both main reports and subreports, resulting in consistent output.
* **Tests**
  * Added an integration test to confirm Pentaho reports are generated against the requesting tenant’s database (and that outputs differ between tenants as expected).
  * Updated supporting test utilities to run reports for specific tenants during assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->