### PR TITLE
feat(migration): implement M2M generation engine and SQL translator

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/BirtDomBuilder.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/BirtDomBuilder.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.fineract.infrastructure.report.migration.model.PentahoParameter;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoSqlDataset;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+@Component
+public class BirtDomBuilder {
+
+    private final PentahoSqlTranslator sqlTranslator;
+    private final AtomicInteger idGenerator = new AtomicInteger(100); // Prevents ID collisions
+
+    public BirtDomBuilder(PentahoSqlTranslator sqlTranslator) {
+        this.sqlTranslator = sqlTranslator;
+    }
+
+    /**
+     * Programmatically generates a BIRT .rptdesign XML Document from the IR.
+     */
+    public Document buildReportDocument(PentahoReportModel pentahoModel) throws ParserConfigurationException {
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+
+        // 1. Root <report> node
+        Element root = document.createElement("report");
+        root.setAttribute("xmlns", "http://www.eclipse.org/birt/2005/design");
+        root.setAttribute("version", "3.2.27");
+        root.setAttribute("id", "1");
+        document.appendChild(root);
+
+        // 2. Report Parameters
+        if (pentahoModel.parameters() != null && !pentahoModel.parameters().isEmpty()) {
+            Element paramsNode = appendNode(document, root, "parameters");
+            for (PentahoParameter param : pentahoModel.parameters()) {
+                buildScalarParameter(document, paramsNode, param);
+            }
+        }
+
+        // 3. Data Sources (Hardcoded to Fineract standard tenant DB for generation)
+        Element dataSourcesNode = appendNode(document, root, "data-sources");
+        buildDefaultDataSource(document, dataSourcesNode);
+
+        // 4. Data Sets
+        if (pentahoModel.datasets() != null && !pentahoModel.datasets().isEmpty()) {
+            Element dataSetsNode = appendNode(document, root, "data-sets");
+            for (PentahoSqlDataset dataset : pentahoModel.datasets()) {
+                buildDataset(document, dataSetsNode, dataset);
+            }
+        }
+
+        return document;
+    }
+
+    private void buildScalarParameter(Document doc, Element parent, PentahoParameter param) {
+        Element scalarNode = appendNode(doc, parent, "scalar-parameter");
+        scalarNode.setAttribute("name", param.name());
+        scalarNode.setAttribute("id", String.valueOf(idGenerator.incrementAndGet()));
+
+        appendProperty(doc, scalarNode, "valueType", "static");
+        appendProperty(doc, scalarNode, "dataType", mapPentahoTypeToBirt(param.type()));
+        appendProperty(doc, scalarNode, "paramType", "simple");
+        appendProperty(doc, scalarNode, "controlType", param.isList() ? "list-box" : "text-box");
+        appendProperty(doc, scalarNode, "isRequired", String.valueOf(param.isMandatory()));
+    }
+
+    private void buildDefaultDataSource(Document doc, Element parent) {
+        Element dsNode = appendNode(doc, parent, "oda-data-source");
+        dsNode.setAttribute("extensionID", "org.eclipse.birt.report.data.oda.jdbc");
+        dsNode.setAttribute("name", "Data Source");
+        dsNode.setAttribute("id", "7");
+
+        appendProperty(doc, dsNode, "odaDriverClass", "org.postgresql.Driver");
+        appendProperty(doc, dsNode, "odaURL", "jdbc:postgresql://127.0.0.1:5432/fineract_default");
+        appendProperty(doc, dsNode, "odaUser", "postgres");
+    }
+
+    private void buildDataset(Document doc, Element parent, PentahoSqlDataset dataset) {
+        Element dsNode = appendNode(doc, parent, "oda-data-set");
+        dsNode.setAttribute("extensionID", "org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet");
+        dsNode.setAttribute("name", dataset.queryName());
+        dsNode.setAttribute("id", String.valueOf(idGenerator.incrementAndGet()));
+
+        appendProperty(doc, dsNode, "dataSource", "Data Source");
+
+        // Translate the SQL and extract ordered parameters
+        TranslatedQuery translatedQuery = sqlTranslator.translateToPositional(dataset.sqlQuery());
+        
+        Element queryTextNode = appendNode(doc, dsNode, "xml-property");
+        queryTextNode.setAttribute("name", "queryText");
+        queryTextNode.appendChild(doc.createCDATASection(translatedQuery.birtSqlQuery()));
+
+        // Map the positional parameters dynamically
+        if (!translatedQuery.orderedParameterNames().isEmpty()) {
+            Element listPropNode = appendNode(doc, dsNode, "list-property");
+            listPropNode.setAttribute("name", "parameters");
+            
+            int position = 1;
+            for (String paramName : translatedQuery.orderedParameterNames()) {
+                Element structNode = appendNode(doc, listPropNode, "structure");
+                appendProperty(doc, structNode, "name", paramName);
+                appendProperty(doc, structNode, "paramName", paramName);
+                appendProperty(doc, structNode, "dataType", "string"); // Default fallback
+                appendProperty(doc, structNode, "position", String.valueOf(position++));
+                appendProperty(doc, structNode, "isInput", "true");
+                appendProperty(doc, structNode, "isOutput", "false");
+            }
+        }
+    }
+
+    private String mapPentahoTypeToBirt(String pentahoType) {
+        if (pentahoType == null) return "string";
+        return switch (pentahoType.toLowerCase()) {
+            case "numeric", "integer", "long" -> "integer";
+            case "date" -> "date";
+            case "decimal", "float", "double" -> "decimal";
+            default -> "string";
+        };
+    }
+
+    // --- DRY Elimination Helpers ---
+
+    private Element appendNode(Document doc, Element parent, String tagName) {
+        Element element = doc.createElement(tagName);
+        parent.appendChild(element);
+        return element;
+    }
+
+    private void appendProperty(Document doc, Element parent, String propertyName, String textContent) {
+        Element property = doc.createElement("property");
+        property.setAttribute("name", propertyName);
+        property.setTextContent(textContent);
+        parent.appendChild(property);
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/PentahoSqlTranslator.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/PentahoSqlTranslator.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PentahoSqlTranslator {
+
+    // Matches Pentaho named parameters: ${paramName}
+    private static final Pattern PENTAHO_PARAM_PATTERN = Pattern.compile("\\$\\{([a-zA-Z0-9_]+)\\}");
+
+    /**
+     * Translates a legacy Pentaho SQL query into a BIRT-compatible positional query.
+     *
+     * @param legacySql The raw SQL from Pentaho.
+     * @return A TranslatedQuery containing the new SQL and ordered parameters.
+     */
+    public TranslatedQuery translateToPositional(String legacySql) {
+        if (legacySql == null || legacySql.isBlank()) {
+            return new TranslatedQuery("", List.of());
+        }
+
+        Matcher matcher = PENTAHO_PARAM_PATTERN.matcher(legacySql);
+        List<String> orderedParams = new ArrayList<>();
+        StringBuilder birtSql = new StringBuilder();
+
+        while (matcher.find()) {
+            // Group 1 extracts just the parameter name without the ${}
+            orderedParams.add(matcher.group(1));
+            // Replace the named parameter with BIRT's positional '?'
+            matcher.appendReplacement(birtSql, "?");
+        }
+        matcher.appendTail(birtSql);
+
+        // MX-311: Dialect-Aware replacements can be chained here if needed in the future
+        // e.g., birtSql = replaceMariaDbFunctionsWithPostgres(birtSql.toString());
+
+        return new TranslatedQuery(birtSql.toString(), orderedParams);
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/ReportModelMapper.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/ReportModelMapper.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import java.io.StringWriter;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+
+@Service
+public class ReportModelMapper {
+
+    private final BirtDomBuilder domBuilder;
+
+    public ReportModelMapper(BirtDomBuilder domBuilder) {
+        this.domBuilder = domBuilder;
+    }
+
+    /**
+     * Maps the Pentaho IR into a raw BIRT .rptdesign XML String.
+     */
+    public String mapToBirtTemplate(PentahoReportModel pentahoModel) {
+        try {
+            Document birtDocument = domBuilder.buildReportDocument(pentahoModel);
+            return transformDocumentToString(birtDocument);
+        } catch (ParserConfigurationException | TransformerException e) {
+            throw new RuntimeException("Failed to generate BIRT XML DOM for report: " + pentahoModel.reportName(), e);
+        }
+    }
+
+    private String transformDocumentToString(Document document) throws TransformerException {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        
+        // Ensure standard BIRT formatting
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        StringWriter writer = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(writer));
+        return writer.toString();
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/TranslatedQuery.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/generator/TranslatedQuery.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import java.util.List;
+
+/**
+ * Holds the translated BIRT-compatible SQL query and the ordered list of 
+ * parameter names required for positional binding.
+ */
+public record TranslatedQuery(
+    String birtSqlQuery,
+    List<String> orderedParameterNames
+) {}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/generator/BirtDomBuilderTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/generator/BirtDomBuilderTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import java.util.List;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.fineract.infrastructure.report.migration.model.PentahoParameter;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoSqlDataset;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.anyString;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+@ExtendWith(MockitoExtension.class)
+class BirtDomBuilderTest {
+
+    @Mock
+    private PentahoSqlTranslator sqlTranslator;
+
+    @InjectMocks
+    private BirtDomBuilder domBuilder;
+
+    private XPath xPath;
+
+    @BeforeEach
+    void setUp() {
+        xPath = XPathFactory.newInstance().newXPath();
+    }
+
+    @Test
+    void givenValidReportModel_whenBuildDocument_thenCreatesProperXmlDom() throws Exception {
+        // Arrange
+        PentahoParameter param = new PentahoParameter("branchId", "integer", true, "1", false, null);
+        PentahoSqlDataset dataset = new PentahoSqlDataset("ActiveLoans", "SELECT * FROM dummy");
+        PentahoReportModel model = new PentahoReportModel("TestReport", List.of(dataset), List.of(param), List.of());
+
+        when(sqlTranslator.translateToPositional(anyString()))
+                .thenReturn(new TranslatedQuery("SELECT * FROM dummy WHERE id = ?", List.of("branchId")));
+
+        // Act
+        Document document = domBuilder.buildReportDocument(model);
+
+        // Assert - Root Node
+        Element root = document.getDocumentElement();
+        assertThat(root.getTagName()).isEqualTo("report");
+        assertThat(root.getAttribute("version")).isEqualTo("3.2.27");
+
+        // Assert - Parameters Node
+        NodeList paramNodes = (NodeList) xPath.evaluate("//parameters/scalar-parameter", document, XPathConstants.NODESET);
+        assertThat(paramNodes.getLength()).isEqualTo(1);
+        Element scalarParam = (Element) paramNodes.item(0);
+        assertThat(scalarParam.getAttribute("name")).isEqualTo("branchId");
+
+        // Assert - Data Sources
+        NodeList dsNodes = (NodeList) xPath.evaluate("//data-sources/oda-data-source", document, XPathConstants.NODESET);
+        assertThat(dsNodes.getLength()).isEqualTo(1);
+        Element dataSource = (Element) dsNodes.item(0);
+        assertThat(dataSource.getAttribute("name")).isEqualTo("Data Source");
+
+        // Assert - Data Sets and Positional Parameter mapping
+        NodeList dataSetNodes = (NodeList) xPath.evaluate("//data-sets/oda-data-set", document, XPathConstants.NODESET);
+        assertThat(dataSetNodes.getLength()).isEqualTo(1);
+        Element dataSet = (Element) dataSetNodes.item(0);
+        assertThat(dataSet.getAttribute("name")).isEqualTo("ActiveLoans");
+
+        String queryText = (String) xPath.evaluate(".//xml-property[@name='queryText']/text()", dataSet, XPathConstants.STRING);
+        assertThat(queryText).contains("SELECT * FROM dummy WHERE id = ?");
+
+        String paramMappingName = (String) xPath.evaluate(".//list-property[@name='parameters']/structure/property[@name='paramName']/text()", dataSet, XPathConstants.STRING);
+        assertThat(paramMappingName).isEqualTo("branchId");
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/generator/PentahoSqlTranslatorTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/generator/PentahoSqlTranslatorTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PentahoSqlTranslatorTest {
+
+    private PentahoSqlTranslator translator;
+
+    @BeforeEach
+    void setUp() {
+        translator = new PentahoSqlTranslator();
+    }
+
+    @Test
+    void givenQueryWithNamedParameters_whenTranslated_thenReplacesWithPositionalAndExtractsNames() {
+        String legacySql = "SELECT * FROM m_loan l WHERE l.branch_id = ${branchId} AND l.status = ${loanStatus}";
+
+        TranslatedQuery result = translator.translateToPositional(legacySql);
+
+        assertThat(result.birtSqlQuery()).isEqualTo("SELECT * FROM m_loan l WHERE l.branch_id = ? AND l.status = ?");
+        assertThat(result.orderedParameterNames()).containsExactly("branchId", "loanStatus");
+    }
+
+    @Test
+    void givenQueryWithNoParameters_whenTranslated_thenReturnsOriginalQuery() {
+        String legacySql = "SELECT * FROM m_office";
+
+        TranslatedQuery result = translator.translateToPositional(legacySql);
+
+        assertThat(result.birtSqlQuery()).isEqualTo(legacySql);
+        assertThat(result.orderedParameterNames()).isEmpty();
+    }
+
+    @Test
+    void givenQueryWithRepeatedParameters_whenTranslated_thenExtractsAllInOrder() {
+        String legacySql = "SELECT * FROM m_loan WHERE start_date > ${date} AND end_date < ${date}";
+
+        TranslatedQuery result = translator.translateToPositional(legacySql);
+
+        assertThat(result.birtSqlQuery()).isEqualTo("SELECT * FROM m_loan WHERE start_date > ? AND end_date < ?");
+        assertThat(result.orderedParameterNames()).containsExactly("date", "date");
+    }
+
+    @Test
+    void givenNullOrBlankQuery_whenTranslated_thenReturnsEmptyResult() {
+        TranslatedQuery nullResult = translator.translateToPositional(null);
+        TranslatedQuery blankResult = translator.translateToPositional("   ");
+
+        assertThat(nullResult.birtSqlQuery()).isEmpty();
+        assertThat(nullResult.orderedParameterNames()).isEmpty();
+
+        assertThat(blankResult.birtSqlQuery()).isEmpty();
+        assertThat(blankResult.orderedParameterNames()).isEmpty();
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/generator/ReportModelMapperTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/generator/ReportModelMapperTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.generator;
+
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+@ExtendWith(MockitoExtension.class)
+class ReportModelMapperTest {
+
+    @Mock
+    private BirtDomBuilder domBuilder;
+
+    @InjectMocks
+    private ReportModelMapper reportModelMapper;
+
+    @Test
+    void givenReportModel_whenMapped_thenTransformsDomToXmlString() throws Exception {
+        // Arrange
+        Document dummyDoc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = dummyDoc.createElement("report");
+        root.setAttribute("testAttribute", "success");
+        dummyDoc.appendChild(root);
+
+        when(domBuilder.buildReportDocument(any(PentahoReportModel.class))).thenReturn(dummyDoc);
+
+        PentahoReportModel dummyModel = new PentahoReportModel("Dummy", List.of(), List.of(), List.of());
+
+        // Act
+        String resultXml = reportModelMapper.mapToBirtTemplate(dummyModel);
+
+        // Assert
+
+        assertThat(resultXml).contains("<?xml version=\"1.0\"");
+        assertThat(resultXml).contains("encoding=\"UTF-8\"");
+        assertThat(resultXml).contains("<report testAttribute=\"success\"/>");
+    }
+}


### PR DESCRIPTION
- Resolves MX-307, MX-308, MX-309, MX-310, and MX-311
- Implement PentahoSqlTranslator to convert legacy named SQL parameters (${param}) into BIRT positional parameters (?)
- Build BirtDomBuilder to programmatically generate BIRT XML DOM from Intermediate Representation (IR) models
- Add private DOM helper methods to strictly enforce the DRY principle
- Create ReportModelMapper to transform the XML Document into a formatted, ready-to-write UTF-8 string
- Add comprehensive JUnit 5 tests utilizing XPath and Mockito, achieving >85% JaCoCo coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting Pentaho report models into BIRT report templates.
  * Generated templates now include report parameters, JDBC data sources, datasets, SQL queries, and parameter mappings.
  * Added translation of named SQL parameters into BIRT-compatible positional parameters.
  * Added formatted UTF-8 XML output for generated report templates.

* **Tests**
  * Added coverage for report generation, SQL translation, parameter handling, and XML serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->