### PR TITLE
feat(migration): implement Pentaho to BIRT data type normalization utility

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/util/BirtDataTypeMapper.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/util/BirtDataTypeMapper.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.util;
+
+import java.util.Map;
+
+/** Maps standard Pentaho/Java type names to lowercase BIRT type names. */
+public final class BirtDataTypeMapper {
+
+  private static final Map<String, String> TYPE_MAPPINGS =
+      Map.ofEntries(
+          Map.entry("java.lang.String", "string"),
+          Map.entry("java.lang.Integer", "integer"),
+          Map.entry("java.lang.Short", "integer"),
+          Map.entry("java.lang.Long", "integer"),
+          Map.entry("java.math.BigInteger", "integer"),
+          Map.entry("java.lang.Number", "decimal"),
+          Map.entry("java.lang.Double", "decimal"),
+          Map.entry("java.lang.Float", "decimal"),
+          Map.entry("java.math.BigDecimal", "decimal"),
+          Map.entry("java.util.Date", "date"),
+          Map.entry("java.sql.Date", "date"),
+          Map.entry("java.sql.Timestamp", "datetime"),
+          Map.entry("java.sql.Time", "datetime"),
+          Map.entry("java.lang.Boolean", "boolean"));
+
+  private BirtDataTypeMapper() {}
+
+  /**
+   * Maps a type name, defaulting null, blank, and unsupported values to {@code string}.
+   *
+   * @param pentahoType type name to map
+   * @return corresponding BIRT type name
+   */
+  public static String mapType(String pentahoType) {
+    if (pentahoType == null || pentahoType.isBlank()) {
+      return "string";
+    }
+    // Using strip() instead of trim() to safely handle Unicode whitespace
+    return TYPE_MAPPINGS.getOrDefault(pentahoType.strip(), "string");
+  }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/util/BirtDataTypeMapperTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/util/BirtDataTypeMapperTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("BirtDataTypeMapper Tests")
+class BirtDataTypeMapperTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "java.lang.String, string",
+    "java.lang.Integer, integer",
+    "java.lang.Short, integer",
+    "java.lang.Long, integer",
+    "java.math.BigInteger, integer",
+    "java.lang.Number, decimal",
+    "java.lang.Double, decimal",
+    "java.lang.Float, decimal",
+    "java.math.BigDecimal, decimal",
+    "java.util.Date, date",
+    "java.sql.Date, date",
+    "java.sql.Timestamp, datetime",
+    "java.sql.Time, datetime",
+    "java.lang.Boolean, boolean"
+  })
+  @DisplayName("Should correctly map standard Pentaho types to BIRT types")
+  void shouldMapStandardTypes(String pentahoType, String expectedBirtType) {
+    assertEquals(expectedBirtType, BirtDataTypeMapper.mapType(pentahoType));
+  }
+
+  @Test
+  @DisplayName("Should fallback to string for unknown or custom data types")
+  void shouldFallbackToStringForUnknownTypes() {
+    assertEquals("string", BirtDataTypeMapper.mapType("org.apache.custom.MyType"));
+    assertEquals("string", BirtDataTypeMapper.mapType("java.util.UUID"));
+  }
+
+  @Test
+  @DisplayName("Should handle null, empty, and whitespace gracefully")
+  void shouldHandleNullAndEmptyGracefully() {
+    assertEquals("string", BirtDataTypeMapper.mapType(null));
+    assertEquals("string", BirtDataTypeMapper.mapType(""));
+    assertEquals("string", BirtDataTypeMapper.mapType("   "));
+  }
+
+  @Test
+  @DisplayName("Should correctly map types with leading or trailing whitespace")
+  void shouldMapTypesWithWhitespace() {
+    assertEquals("integer", BirtDataTypeMapper.mapType(" java.lang.Integer "));
+    assertEquals("date", BirtDataTypeMapper.mapType("java.util.Date\t"));
+    // Verifying Unicode whitespace handling (CodeRabbit request)
+    assertEquals("integer", BirtDataTypeMapper.mapType("\u2003java.lang.Integer\u2003"));
+  }
+}


### PR DESCRIPTION
Overview
This PR introduces the first foundational component of the Phase 3 (M2M Generation) pipeline.

BIRT requires strictly typed lowercase string declarations for parameters (e.g., "string", "integer", "date"), whereas legacy Pentaho .prpt files store parameter data types as fully qualified Java class names (e.g., "java.lang.String", "java.util.Date").

This PR implements an isolated normalization utility (BirtDataTypeMapper) that safely translates the Intermediate Representation (IR) Pentaho types into BIRT-compliant types.

Resolves:
MX-307: Implement Pentaho to BIRT Data Type Normalization Utility

Key Implementations
BirtDataTypeMapper: A standalone utility mapping 14 standard Pentaho Java data types to their BIRT equivalents.

Safe Fallbacks: Designed to prevent generation engine crashes. If an unknown custom type, null, or empty string is encountered during parsing, the mapper safely defaults the BIRT parameter to "string".

Testing & Code Quality
Achieved 100% JaCoCo branch and line coverage for the new utility class.

Implemented JUnit @ParameterizedTest to boundary-test all 14 standard type mappings.

Explicitly tested edge cases including null, blank strings, custom unmapped class names, and whitespace trimming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic mapping of common report data types to compatible BIRT type strings, improving consistency across reports.
  * Unknown, blank, or unsupported type inputs now safely default to a string type (including trimming whitespace).

* **Tests**
  * Added coverage for standard mappings, fallback behavior, null/blank values, and whitespace handling (including Unicode whitespace).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->