### PR TITLE
MX-310: Wire up Pentaho datasets and parameters into the BIRT DOM

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/builder/BirtReportAssembler.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/builder/BirtReportAssembler.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.builder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoParameter;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoSqlDataset;
+import org.apache.fineract.infrastructure.report.migration.util.BirtDataTypeMapper;
+import org.apache.fineract.infrastructure.report.migration.util.PentahoSqlTranslator;
+import org.apache.fineract.infrastructure.report.migration.util.TranslatedQuery;
+import org.w3c.dom.CDATASection;
+import org.w3c.dom.Element;
+
+/** Orchestrates the translation and injection of Pentaho IR models into the BIRT XML DOM. */
+public class BirtReportAssembler {
+
+  private final BirtDomBuilder domBuilder;
+  private final AtomicInteger elementIdCounter = new AtomicInteger(100);
+
+  public BirtReportAssembler(BirtDomBuilder domBuilder) {
+    this.domBuilder = domBuilder;
+  }
+
+  public void assemble(PentahoReportModel reportModel) {
+    if (reportModel == null) {
+      return;
+    }
+    buildReportParameters(reportModel.parameters());
+    buildDataSets(reportModel.datasets(), reportModel.parameters());
+  }
+
+  private void buildReportParameters(List<PentahoParameter> parameters) {
+    if (parameters == null || parameters.isEmpty()) return;
+    Element parametersNode = domBuilder.appendElement(domBuilder.getReportRoot(), "parameters");
+    for (PentahoParameter param : parameters) {
+      buildSingleParameter(parametersNode, param);
+    }
+  }
+
+  private void buildSingleParameter(Element parametersNode, PentahoParameter param) {
+    Element scalarParam = domBuilder.appendElement(parametersNode, "scalar-parameter");
+    scalarParam.setAttribute("name", param.name());
+    scalarParam.setAttribute("id", String.valueOf(elementIdCounter.getAndIncrement()));
+
+    domBuilder.appendProperty(scalarParam, "valueType", "static");
+    domBuilder.appendProperty(scalarParam, "dataType", BirtDataTypeMapper.mapType(param.type()));
+    domBuilder.appendProperty(scalarParam, "paramType", "simple");
+    domBuilder.appendProperty(scalarParam, "controlType", "text-box");
+
+    if (param.isMandatory()) {
+      domBuilder.appendProperty(scalarParam, "isRequired", "true");
+    }
+
+    if (param.defaultValue() != null && !param.defaultValue().isBlank()) {
+      Element defaultList = domBuilder.appendElement(scalarParam, "simple-property-list");
+      defaultList.setAttribute("name", "defaultValue");
+      Element val = domBuilder.appendElement(defaultList, "value");
+      val.setAttribute("type", "constant");
+      val.setTextContent(param.defaultValue()); // Retain intentional whitespace
+    }
+  }
+
+  private void buildDataSets(List<PentahoSqlDataset> datasets, List<PentahoParameter> parameters) {
+    if (datasets == null || datasets.isEmpty()) return;
+    Element dataSetsNode = domBuilder.appendElement(domBuilder.getReportRoot(), "data-sets");
+
+    Map<String, PentahoParameter> paramMap =
+        parameters == null
+            ? Map.of()
+            : parameters.stream()
+                .collect(Collectors.toMap(PentahoParameter::name, p -> p, (p1, p2) -> p1));
+
+    for (PentahoSqlDataset dataset : datasets) {
+      buildSingleDataSet(dataSetsNode, dataset, paramMap);
+    }
+  }
+
+  private void buildSingleDataSet(
+      Element dataSetsNode, PentahoSqlDataset dataset, Map<String, PentahoParameter> paramMap) {
+    Element odaDataSet = domBuilder.appendElement(dataSetsNode, "oda-data-set");
+    odaDataSet.setAttribute(
+        "extensionID", "org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet");
+    odaDataSet.setAttribute("name", dataset.queryName());
+    odaDataSet.setAttribute("id", String.valueOf(elementIdCounter.getAndIncrement()));
+    domBuilder.appendProperty(odaDataSet, "dataSource", "Data Source");
+
+    TranslatedQuery translated = PentahoSqlTranslator.translate(dataset.sqlQuery());
+    Element queryText = domBuilder.appendElement(odaDataSet, "xml-property");
+    queryText.setAttribute("name", "queryText");
+
+    String sql = translated.sql();
+    if (sql.contains("]]>")) {
+      queryText.setTextContent(sql);
+    } else {
+      CDATASection cdata = domBuilder.getDocument().createCDATASection(sql);
+      queryText.appendChild(cdata);
+    }
+
+    injectDatasetParameters(odaDataSet, dataset.queryName(), translated.parameterNames(), paramMap);
+  }
+
+  private void injectDatasetParameters(
+      Element odaDataSet,
+      String queryName,
+      List<String> queryParams,
+      Map<String, PentahoParameter> paramMap) {
+    if (queryParams.isEmpty()) return;
+    Element listProp = domBuilder.appendElement(odaDataSet, "list-property");
+    listProp.setAttribute("name", "parameters");
+    int position = 1;
+
+    for (String paramName : queryParams) {
+      PentahoParameter pInfo = paramMap.get(paramName);
+      if (pInfo == null) {
+        throw new IllegalStateException(
+            String.format("Dataset '%s' references missing parameter '%s'", queryName, paramName));
+      }
+
+      Element structure = domBuilder.appendElement(listProp, "structure");
+      domBuilder.appendProperty(structure, "name", paramName + "_" + position);
+      domBuilder.appendProperty(structure, "paramName", paramName);
+      domBuilder.appendProperty(structure, "dataType", BirtDataTypeMapper.mapType(pInfo.type()));
+      domBuilder.appendProperty(structure, "position", String.valueOf(position));
+      domBuilder.appendProperty(structure, "isInput", "true");
+      domBuilder.appendProperty(structure, "isOutput", "false");
+      position++;
+    }
+  }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/builder/BirtReportAssemblerTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/builder/BirtReportAssemblerTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoParameter;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoReportModel;
+import org.apache.fineract.infrastructure.report.migration.model.PentahoSqlDataset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+
+@DisplayName("BirtReportAssembler Tests")
+class BirtReportAssemblerTest {
+
+  private BirtDomBuilder domBuilder;
+  private BirtReportAssembler assembler;
+  private XPath xpath;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    domBuilder = new BirtDomBuilder();
+    assembler = new BirtReportAssembler(domBuilder);
+    xpath = XPathFactory.newInstance().newXPath();
+  }
+
+  private Node getNode(String expression) throws XPathExpressionException {
+    return (Node) xpath.evaluate(expression, domBuilder.getDocument(), XPathConstants.NODE);
+  }
+
+  private String getString(Node context, String expression) throws XPathExpressionException {
+    return xpath.evaluate(expression, context);
+  }
+
+  @Test
+  @DisplayName("Should assemble global report parameters and preserve whitespace")
+  void shouldAssembleReportParameters() throws Exception {
+    PentahoParameter param =
+        new PentahoParameter("startDate", "java.util.Date", true, "  2023-01-01  ", false, null);
+    assembler.assemble(new PentahoReportModel("Test", List.of(), List.of(param), List.of()));
+
+    Node paramNode = getNode("/report/parameters/scalar-parameter[@name='startDate']");
+    assertThat(paramNode).isNotNull();
+    assertThat(getString(paramNode, "property[@name='dataType']/text()")).isEqualTo("date");
+    assertThat(getString(paramNode, "property[@name='isRequired']/text()")).isEqualTo("true");
+    assertThat(getString(paramNode, "simple-property-list[@name='defaultValue']/value/text()"))
+        .isEqualTo("  2023-01-01  "); // Verifies whitespace is fully preserved
+  }
+
+  @Test
+  @DisplayName("Should assemble datasets with distinct and repeated positional parameters")
+  void shouldAssembleDataSets() throws Exception {
+    setupComplexDatasetFixture();
+    Node datasetNode = getNode("/report/data-sets/oda-data-set[@name='MainDS']");
+
+    assertThat(datasetNode).isNotNull();
+    assertThat(getString(datasetNode, "xml-property[@name='queryText']/text()"))
+        .isEqualTo("SELECT * FROM offices WHERE id = ? AND status = ? OR parent_id = ?");
+
+    assertBinding(datasetNode, 1, "officeId_1", "officeId", "integer");
+    assertBinding(datasetNode, 2, "status_2", "status", "string");
+    assertBinding(datasetNode, 3, "officeId_3", "officeId", "integer");
+  }
+
+  private void setupComplexDatasetFixture() {
+    PentahoParameter p1 =
+        new PentahoParameter("officeId", "java.lang.Integer", false, null, false, null);
+    PentahoParameter p2 =
+        new PentahoParameter("status", "java.lang.String", false, null, false, null);
+    PentahoSqlDataset dataset =
+        new PentahoSqlDataset(
+            "MainDS",
+            "SELECT * FROM offices WHERE id = ${officeId} AND status = ${status} OR parent_id = ${officeId}");
+    assembler.assemble(
+        new PentahoReportModel("TestReport", List.of(dataset), List.of(p1, p2), List.of()));
+  }
+
+  private void assertBinding(
+      Node dsNode, int pos, String expectedName, String expectedParamName, String expectedType)
+      throws Exception {
+    Node struct =
+        (Node)
+            xpath.evaluate(
+                "list-property[@name='parameters']/structure[" + pos + "]",
+                dsNode,
+                XPathConstants.NODE);
+    assertThat(getString(struct, "property[@name='name']/text()")).isEqualTo(expectedName);
+    assertThat(getString(struct, "property[@name='paramName']/text()"))
+        .isEqualTo(expectedParamName);
+    assertThat(getString(struct, "property[@name='dataType']/text()")).isEqualTo(expectedType);
+    assertThat(getString(struct, "property[@name='position']/text()"))
+        .isEqualTo(String.valueOf(pos));
+  }
+
+  @Test
+  @DisplayName("Should reject dataset when referencing an undeclared report parameter")
+  void shouldRejectMissingParameter() {
+    PentahoSqlDataset ds =
+        new PentahoSqlDataset("BadDS", "SELECT * FROM t WHERE id = ${missingId}");
+    PentahoReportModel model = new PentahoReportModel("Test", List.of(ds), List.of(), List.of());
+
+    assertThatThrownBy(() -> assembler.assemble(model))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Dataset 'BadDS' references missing parameter 'missingId'");
+  }
+
+  @Test
+  @DisplayName("Should gracefully handle null models and empty lists")
+  void shouldHandleNulls() {
+    assembler.assemble(null);
+    assembler.assemble(new PentahoReportModel("EmptyNulls", null, null, null));
+    assembler.assemble(new PentahoReportModel("EmptyLists", List.of(), List.of(), List.of()));
+
+    // Verify DOM builder remained completely intact and threw no errors
+    assertThat(domBuilder.getDocument().getDocumentElement()).isNotNull();
+  }
+}


### PR DESCRIPTION
This PR acts as the bridge between our parsed Pentaho IR models (from Phase 1) and the BIRT XML DOM builder we set up in MX-309. 

**What's included:**
* **`BirtReportAssembler`:** The main orchestrator that iterates through the parsed models and injects them into the XML tree.
* **Dataset & SQL Injection:** Takes the legacy Pentaho queries, runs them through our SQL translator, and securely drops the standard SQL into CDATA blocks inside `<oda-data-set>`.
* **Parameter Binding:** Automatically maps data types and binds positional SQL parameters into BIRT's `<list-property>` structures. 
* **Dynamic ID Generation:** I added an atomic element ID counter (starting at 100) for the generated BIRT nodes. This ensures we don't accidentally create ID collisions when translating massive legacy reports.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for converting migrated report definitions into BIRT-compatible report structures.
  - Report parameters now retain data types, required status, and default values.
  - SQL datasets and their positional parameters are translated for JDBC-based reporting.

- **Bug Fixes**
  - Empty or missing report definitions are handled safely without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->