### PR TITLE
MX-311: implement XML transformer and BIRT report exporter

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/exporter/BirtXmlExportException.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/exporter/BirtXmlExportException.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.exporter;
+
+/**
+ * Domain-specific exception for failures encountered during BIRT XML serialization or file output.
+ */
+public class BirtXmlExportException extends RuntimeException {
+
+  public BirtXmlExportException(String message) {
+    super(message);
+  }
+
+  public BirtXmlExportException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/migration/exporter/BirtXmlExporter.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/migration/exporter/BirtXmlExporter.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.exporter;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.XMLConstants;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+
+/** Serializes the in-memory BIRT DOM into formatted XML strings or physical .rptdesign files. */
+public class BirtXmlExporter {
+
+  private static final String ENCODING_UTF8 = "UTF-8";
+  private static final String FEATURE_ENABLED = "yes";
+  private static final String XSLT_INDENT_AMOUNT_KEY = "{http://xml.apache.org/xslt}indent-amount";
+  private static final String XSLT_INDENT_AMOUNT_VALUE = "4";
+
+  /**
+   * Transforms the DOM Document into a formatted UTF-8 XML String.
+   *
+   * @param document the populated BIRT report DOM
+   * @return the serialized XML string
+   * @throws BirtXmlExportException if the transformation fails
+   */
+  public String exportAsString(Document document) {
+    if (document == null) {
+      throw new BirtXmlExportException("Cannot export a null Document");
+    }
+
+    try {
+      Transformer transformer = createSecureTransformer();
+      StringWriter writer = new StringWriter();
+      transformer.transform(new DOMSource(document), new StreamResult(writer));
+      return writer.toString();
+    } catch (TransformerException e) {
+      throw new BirtXmlExportException("Failed to export BIRT DOM to XML string", e);
+    }
+  }
+
+  /**
+   * Serializes the DOM Document directly to the specified filesystem path using streams to minimize
+   * memory footprint on large reports. Uses an atomic temporary file swap to prevent data loss on
+   * failure.
+   *
+   * @param document the populated BIRT report DOM
+   * @param outputPath the destination file path
+   * @throws BirtXmlExportException if file writing or transformation fails
+   */
+  public void exportToFile(Document document, Path outputPath) {
+    if (document == null) {
+      throw new BirtXmlExportException("Cannot export a null Document");
+    }
+    if (outputPath == null) {
+      throw new BirtXmlExportException("Output path cannot be null");
+    }
+
+    Path tempFile = null;
+    try {
+      // Resolve absolute path to guarantee a parent directory on the same filesystem
+      Path absoluteTarget = outputPath.toAbsolutePath();
+      Path parentDir = absoluteTarget.getParent();
+
+      if (parentDir != null) {
+        Files.createDirectories(parentDir);
+      }
+
+      // Create temp file in the exact same directory to ensure ATOMIC_MOVE succeeds
+      tempFile = Files.createTempFile(parentDir, "birt_export_", ".rptdesign.tmp");
+
+      try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(tempFile))) {
+        Transformer transformer = createSecureTransformer();
+        transformer.transform(new DOMSource(document), new StreamResult(os));
+      }
+
+      // Strictly enforce atomic replacement to prevent undefined file states
+      Files.move(
+          tempFile,
+          outputPath,
+          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+    } catch (IOException | TransformerException e) {
+      throw new BirtXmlExportException("Failed to write BIRT XML to file: " + outputPath, e);
+    } finally {
+      if (tempFile != null) {
+        try {
+          Files.deleteIfExists(tempFile);
+        } catch (IOException ignored) {
+          // Ignore cleanup failures
+        }
+      }
+    }
+  }
+
+  private Transformer createSecureTransformer() throws TransformerConfigurationException {
+    TransformerFactory factory = TransformerFactory.newInstance();
+
+    // Fail-closed: Must enforce secure processing
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+    // Fail-closed: Must explicitly disable external entities for secure XML serialization
+    applyConfiguration(
+        () -> {
+          factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+          factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        },
+        "JAXP implementation does not support external entity restriction");
+
+    Transformer transformer = factory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.ENCODING, ENCODING_UTF8);
+    transformer.setOutputProperty(OutputKeys.INDENT, FEATURE_ENABLED);
+
+    // Fail-closed: Must enforce the 4-space Fineract formatting standard
+    applyConfiguration(
+        () -> {
+          transformer.setOutputProperty(XSLT_INDENT_AMOUNT_KEY, XSLT_INDENT_AMOUNT_VALUE);
+        },
+        "JAXP implementation does not support strict 4-space indentation");
+
+    return transformer;
+  }
+
+  /**
+   * Helper method to functionally wrap configuration actions that may throw
+   * IllegalArgumentExceptions if the underlying JAXP provider does not support specific security or
+   * formatting extensions.
+   */
+  private void applyConfiguration(Runnable configAction, String errorMessage)
+      throws TransformerConfigurationException {
+    try {
+      configAction.run();
+    } catch (IllegalArgumentException e) {
+      throw new TransformerConfigurationException(errorMessage, e);
+    }
+  }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/migration/exporter/BirtXmlExporterTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/migration/exporter/BirtXmlExporterTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.migration.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.fineract.infrastructure.report.migration.builder.BirtDomBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+
+@DisplayName("BirtXmlExporter Tests")
+class BirtXmlExporterTest {
+
+  private BirtXmlExporter exporter;
+  private Document mockDocument;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    exporter = new BirtXmlExporter();
+
+    BirtDomBuilder builder = new BirtDomBuilder();
+    builder.appendProperty(builder.getReportRoot(), "testProp", "CodeRabbit");
+    mockDocument = builder.getDocument();
+  }
+
+  @Test
+  @DisplayName("Should export Document to a formatted XML string")
+  void shouldExportAsString() {
+    String xmlOutput = exporter.exportAsString(mockDocument);
+
+    assertThat(xmlOutput).isNotBlank();
+
+    // Safer assertions that don't depend on strict standalone attributes
+    assertThat(xmlOutput).contains("<?xml");
+    assertThat(xmlOutput).contains("encoding=\"UTF-8\"");
+    assertThat(xmlOutput).contains("<report");
+    assertThat(xmlOutput).contains("xmlns=\"http://www.eclipse.org/birt/2005/design\"");
+
+    // Verify indentation logic was applied (normalize CRLF/LF for portability)
+    String normalized = xmlOutput.replace("\r\n", "\n");
+    assertThat(normalized).containsPattern("\n {4}<property name=\"testProp\">");
+    assertThat(normalized).contains("CodeRabbit</property>");
+  }
+
+  @Test
+  @DisplayName("Should export Document directly to filesystem")
+  void shouldExportToFile(@TempDir Path tempDir) throws Exception {
+    Path outputPath = tempDir.resolve("test_report.rptdesign");
+
+    exporter.exportToFile(mockDocument, outputPath);
+
+    assertThat(Files.exists(outputPath)).isTrue();
+    String fileContent = Files.readString(outputPath);
+    String normalized = fileContent.replace("\r\n", "\n");
+    assertThat(normalized).containsPattern("\n {4}<property name=\"testProp\">");
+  }
+
+  @Test
+  @DisplayName("Should reject null arguments gracefully")
+  void shouldRejectNulls() {
+    assertThatThrownBy(() -> exporter.exportAsString(null))
+        .isInstanceOf(BirtXmlExportException.class)
+        .hasMessage("Cannot export a null Document");
+
+    // Add this missing test for the exportToFile document null check
+    assertThatThrownBy(() -> exporter.exportToFile(null, Path.of("unused.rptdesign")))
+        .isInstanceOf(BirtXmlExportException.class)
+        .hasMessage("Cannot export a null Document");
+
+    assertThatThrownBy(() -> exporter.exportToFile(mockDocument, null))
+        .isInstanceOf(BirtXmlExportException.class)
+        .hasMessage("Output path cannot be null");
+  }
+
+  @Test
+  @DisplayName("Should securely replace an existing parentless path using atomic move")
+  void shouldExportToParentlessPath() throws Exception {
+    Path parentlessPath = Path.of("parentless_test_report.rptdesign");
+    try {
+      // Pre-create the file to test the REPLACE_EXISTING and ATOMIC_MOVE logic
+      Files.writeString(parentlessPath, "OLD_DATA_THAT_SHOULD_BE_OVERWRITTEN");
+
+      exporter.exportToFile(mockDocument, parentlessPath);
+
+      assertThat(Files.exists(parentlessPath)).isTrue();
+      String fileContent = Files.readString(parentlessPath);
+      String normalized = fileContent.replace("\r\n", "\n");
+
+      assertThat(normalized).containsPattern("\n {4}<property name=\"testProp\">");
+      assertThat(fileContent).doesNotContain("OLD_DATA_THAT_SHOULD_BE_OVERWRITTEN");
+    } finally {
+      // Clean up the file from the project root after the test
+      Files.deleteIfExists(parentlessPath);
+    }
+  }
+}


### PR DESCRIPTION
This PR handles the serialization step for Phase 3. Now that we have a fully populated BIRT DOM sitting in memory (from MX-309 and MX-310), this utility actually writes it out to a physical `.rptdesign` file.

**What's inside:**
* **`BirtXmlExporter`:** The main utility. I stuck with standard `javax.xml.transform` so we don't bloat the plugin with unnecessary third-party dependencies.
* **Security first:** Explicitly disabled external DTDs and stylesheets in the transformer factory to prevent XXE injection vulnerabilities.
* **Clean formatting:** Enforced UTF-8 encoding and strict 4-space indentation so the resulting XML is actually readable.
* **Output flexibility:** Added `exportAsString()` (great for testing and CLI logs) and `exportToFile()` for the actual physical file generation.
* Pulled all configuration values into static constants to avoid any "magic string" complaints from CodeRabbit.

Fully covered with AssertJ tests (using `@TempDir` to safely verify the file I/O). Let me know if everything looks good!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting BIRT report documents as formatted UTF-8 XML strings.
  * Added support for writing exported report documents directly to files.
  * Improved XML security by blocking external DTDs and stylesheets during export.
  * File exports now preserve existing files until the new export completes successfully.

* **Bug Fixes**
  * Added validation for missing export inputs.
  * Export failures now provide consistent error handling and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->