### PR TITLE
Enforce the report execution boundary for BIRT report SQL

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtParameterMapper.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtParameterMapper.java
@@ -37,8 +37,11 @@ public class BirtParameterMapper {
     private final ReportErrorHandler reportErrorHandler;
     private final IReportEngine reportEngine;
 
-    // Injected separately by BirtContextInjector – never required from the client
-    private static final Set<String> SERVER_MANAGED_PARAMETERS = Set.of("userhierarchy", "userid");
+    /**
+     * Parameters that carry the caller's identity. They are derived from the authenticated user by
+     * {@link BirtContextInjector} and are never accepted from the client.
+     */
+    public static final Set<String> SERVER_MANAGED_PARAMETERS = Set.of("userhierarchy", "userid");
 
     /**
      * Validates and applies report parameters to the BIRT run task.

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
@@ -7,6 +7,9 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import java.io.File;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.RequiredArgsConstructor;
@@ -66,8 +69,7 @@ public class BirtReportLoader {
         if (!reportFile.exists()) {
             log.error("Report design file not found: {}", reportPath);
             throw reportErrorHandler.reportError(
-                    "error.msg.reporting.report.not.found",
-                    "Report file not found: " + reportName + " at path: " + reportPath);
+                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
         }
 
         if (!reportFile.canRead()) {
@@ -143,20 +145,34 @@ public class BirtReportLoader {
                 locale != null ? locale.getLanguage() : "en");
     }
 
-    /** Builds the full path to the .rptdesign file, supporting locale-specific variants. */
+    /**
+     * Builds the full path to the .rptdesign file, supporting locale-specific variants.
+     *
+     * <p>The report name reaches this method straight from the request path, so the resolved file has
+     * to be confined to the reports directory: anything that escapes it is rejected as not found.
+     */
     private String buildReportPath(String reportName, java.util.Locale locale) {
-        String baseDir = getBaseReportsDirectory();
-
-        // Ensure trailing separator
-        if (!baseDir.endsWith(File.separator)) {
-            baseDir += File.separator;
-        }
+        Path baseDir = Paths.get(getBaseReportsDirectory()).toAbsolutePath().normalize();
 
         String languageTag = (locale != null && !"en".equalsIgnoreCase(locale.getLanguage()))
                 ? "_" + locale.getLanguage().toLowerCase()
                 : "";
 
-        return baseDir + reportName + languageTag + ".rptdesign";
+        Path reportPath;
+        try {
+            reportPath =
+                    baseDir.resolve(reportName + languageTag + ".rptdesign").normalize();
+        } catch (InvalidPathException e) {
+            reportPath = null;
+        }
+
+        if (reportPath == null || !reportPath.startsWith(baseDir)) {
+            log.error("Rejected BIRT report name resolving outside the reports directory: {}", reportName);
+            throw reportErrorHandler.reportError(
+                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
+        }
+
+        return reportPath.toString();
     }
 
     /** Returns the base directory for BIRT reports. Priority: Configured path → Default directory */

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
@@ -13,7 +13,9 @@ import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -40,7 +42,6 @@ import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.eclipse.birt.report.engine.api.IRunTask;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.springframework.context.annotation.Primary;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -71,7 +72,7 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
 
     @Override
     public Response processRequest(String reportName, MultivaluedMap<String, String> queryParams) {
-        reportSecurityService.checkReadReportPermission();
+        reportSecurityService.checkReportExecutionPermission(reportName);
         final String outputType = resolveOutputType(queryParams);
         final Locale locale = ApiParameterHelper.extractLocale(queryParams);
         final Map<String, String> reportParams = getReportParams(reportName, queryParams);
@@ -108,15 +109,15 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
         try {
             transactionTemplate.execute(status -> {
                 IRunTask runTask = null;
-                Connection springConnection = null;
+                Connection birtConnection = null;
                 try {
                     final IReportRunnable design = reportExecutionFactory.createExecutionRunnable(reportName, locale);
                     final ReportDesignHandle designHandle = (ReportDesignHandle) design.getDesignHandle();
                     sqlDialectInterpolator.interpolate(designHandle);
                     runTask = reportEngine.createRunTask(design);
                     runTask.setErrorHandlingOption(IEngineTask.CANCEL_ON_ERROR);
-                    springConnection = DataSourceUtils.getConnection(dataSource);
-                    setConnectionDetail(runTask, springConnection);
+                    birtConnection = openReadOnlyConnection();
+                    setConnectionDetail(runTask, birtConnection);
                     configureLocale(runTask, locale);
                     parameterMapper.applyParameters(runTask, reportParams);
                     contextInjector.injectContextParameters(runTask);
@@ -147,11 +148,11 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
                         closeQuietly(runTask::close);
                     }
                     /*
-                     * Do not explicitly close the tenant connection here.
-                     *
-                     * The connection is owned by Spring's transaction
-                     * infrastructure and DataSourceUtils.
+                     * The BIRT connection is not the Spring transaction's
+                     * connection, so this method owns its lifecycle. BIRT
+                     * only ever sees the close-proof proxy.
                      */
+                    releaseReadOnlyConnection(birtConnection);
                 }
             });
         } catch (PlatformDataIntegrityException e) {
@@ -283,7 +284,125 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
         return cleaned.trim();
     }
 
-    private void setConnectionDetail(IRunTask runTask, Connection springConnection) throws Exception {
+    /**
+     * Opens the JDBC connection that BIRT executes the report's embedded SQL on, and puts it in a
+     * read-only transaction before BIRT can use it.
+     *
+     * <p>The read-only flag of the surrounding {@link TransactionTemplate} does not reach this
+     * connection: Fineract's transaction manager is a {@code JpaTransactionManager}, which applies
+     * read-only to the persistence context only and never calls {@link Connection#setReadOnly}. The
+     * guard therefore has to be applied here, on the connection BIRT actually receives, so that the
+     * database refuses the write rather than the plugin trying to recognise one — SQL built at run
+     * time by a report script is invisible to any inspection of the design.
+     *
+     * <p>What the transaction does and does not cover. {@code INSERT}, {@code UPDATE} and
+     * {@code DELETE} are refused on both PostgreSQL and MySQL/MariaDB; DDL is refused on PostgreSQL
+     * only, because MySQL and MariaDB commit implicitly before it. It is not a containment boundary
+     * against a deliberately hostile {@code .rptdesign} either: a design that issues its own
+     * transaction control ({@code COMMIT} followed by {@code START TRANSACTION READ WRITE}) leaves
+     * the read-only transaction behind and can write.
+     *
+     * <p>The boundary that does hold is the database principal, configured per tenant — see
+     * {@link #openTenantReportConnection()}. The transaction stays regardless, because a tenant that
+     * has not configured one still gets the protection the transaction can give.
+     */
+    private Connection openReadOnlyConnection() throws SQLException {
+        final Connection connection = openTenantReportConnection();
+        try {
+            connection.setReadOnly(true);
+            connection.setAutoCommit(false);
+            beginReadOnlyTransaction(connection);
+            /*
+             * Opening the transaction here, with a statement of our own,
+             * closes the cheapest way out of it: a database stops accepting
+             * "SET TRANSACTION READ WRITE" once the transaction has taken
+             * its snapshot. Without this, the first statement of a report
+             * could be that, and a later one a write.
+             */
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SELECT 1");
+            }
+            return connection;
+        } catch (SQLException e) {
+            closeQuietly(connection::close);
+            throw e;
+        }
+    }
+
+    /**
+     * Opens the connection reports run on, as the tenant's read-only database principal when one is
+     * configured.
+     *
+     * <p>A principal granted only {@code SELECT} is the one boundary a report cannot argue with: it
+     * refuses writes, DDL and {@code SET ROLE} alike, and unlike the read-only transaction it cannot
+     * be left behind by a report that opens a transaction of its own.
+     *
+     * <p>The credentials come from the tenant's existing {@code readonly_schema_*} columns, so this
+     * needs no new configuration surface — but those columns are empty in a stock deployment, and
+     * the principal still has to exist in the database. Until an operator sets both up, reports keep
+     * running on the ordinary tenant pool with only the read-only transaction protecting them.
+     * Fields left blank fall back to the read-write ones, so the common case of one database and a
+     * restricted role needs only a username and password.
+     */
+    private Connection openTenantReportConnection() throws SQLException {
+        final FineractPlatformTenantConnection tenantConnection = requireTenantConnection();
+        final String readOnlyUsername = tenantConnection.getReadOnlySchemaUsername();
+
+        if (StringUtils.isBlank(readOnlyUsername)) {
+            return dataSource.getConnection();
+        }
+
+        final String driverClassName =
+                org.apache.fineract.infrastructure.report.util.DataSourceUtils.getDriverClassName(dataSource);
+        final String jdbcUrl = FineractPlatformTenantConnection.toJdbcUrl(
+                FineractPlatformTenantConnection.resolveProtocol(driverClassName),
+                StringUtils.defaultIfBlank(
+                        tenantConnection.getReadOnlySchemaServer(), tenantConnection.getSchemaServer()),
+                StringUtils.defaultIfBlank(
+                        tenantConnection.getReadOnlySchemaServerPort(), tenantConnection.getSchemaServerPort()),
+                StringUtils.defaultIfBlank(tenantConnection.getReadOnlySchemaName(), tenantConnection.getSchemaName()),
+                StringUtils.defaultIfBlank(
+                        tenantConnection.getReadOnlySchemaConnectionParameters(),
+                        tenantConnection.getSchemaConnectionParameters()));
+
+        log.debug("Running BIRT report as the tenant's read-only database principal {}", readOnlyUsername);
+        return DriverManager.getConnection(
+                jdbcUrl,
+                readOnlyUsername,
+                databasePasswordEncryptor.decrypt(
+                        StringUtils.trimToEmpty(tenantConnection.getReadOnlySchemaPassword())));
+    }
+
+    /**
+     * Starts the read-only transaction on databases whose driver will not start one.
+     *
+     * <p>{@link Connection#setReadOnly} is enough on PostgreSQL, whose driver opens every transaction
+     * with {@code BEGIN READ ONLY}. The MySQL and MariaDB drivers treat it as a replica-routing hint
+     * and let every write through untouched, so there the transaction has to be opened explicitly.
+     *
+     * <p>Deliberately a transaction-scoped statement rather than a session-scoped one: the connection
+     * goes back to a pool that Fineract writes through, and {@code SET SESSION} would still be in
+     * effect when the next borrower picks it up.
+     */
+    private void beginReadOnlyTransaction(Connection connection) throws SQLException {
+        final String jdbcUrl = connection.getMetaData().getURL();
+        if (StringUtils.startsWith(jdbcUrl, "jdbc:postgresql")) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("START TRANSACTION READ ONLY");
+        }
+    }
+
+    private void releaseReadOnlyConnection(Connection connection) {
+        if (connection == null) {
+            return;
+        }
+        closeQuietly(connection::rollback);
+        closeQuietly(connection::close);
+    }
+
+    private FineractPlatformTenantConnection requireTenantConnection() {
         final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
         if (tenant == null) {
             throw new PlatformDataIntegrityException(
@@ -295,22 +414,28 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
                     SQL_ERROR_CODE,
                     "Unable to execute BIRT report because the tenant database connection is unavailable.");
         }
-        final String jdbcUrl = springConnection.getMetaData().getURL();
+        return tenantConnection;
+    }
+
+    private void setConnectionDetail(IRunTask runTask, Connection birtConnection) throws Exception {
+        requireTenantConnection();
+        final String jdbcUrl = birtConnection.getMetaData().getURL();
         final String driverClassName =
                 org.apache.fineract.infrastructure.report.util.DataSourceUtils.getDriverClassName(dataSource);
         runTask.getAppContext().put("OdaJDBCDriverClass", driverClassName);
         runTask.getAppContext().put("OdaJDBCDriverUrl", jdbcUrl);
-        runTask.getAppContext().put("OdaJDBCDriverUser", tenantConnection.getSchemaUsername());
-        runTask.getAppContext()
-                .put(
-                        "OdaJDBCDriverPassword",
-                        databasePasswordEncryptor.decrypt(
-                                tenantConnection.getSchemaPassword().trim()));
         /*
-         * The connection belongs to the current Fineract tenant
-         * transaction. BIRT must not close it.
+         * No credentials are published to the report's app context. BIRT's
+         * JDBC ODA driver takes the pass-in connection and returns before it
+         * ever looks at a user or password, so entries for them would only
+         * put the tenant's decrypted database password in a map that report
+         * scripts can reach — and would now name the wrong principal.
          */
-        final Connection safeConnection = wrapConnectionToPreventClose(springConnection);
+        /*
+         * BIRT must not close the connection, nor take it out of the
+         * read-only transaction it was opened in.
+         */
+        final Connection safeConnection = wrapConnectionToPreventClose(birtConnection);
         runTask.getAppContext().put("OdaJDBCDriverPassInConnection", safeConnection);
         runTask.getAppContext().put("OdaJDBCDriverPassInConnectionCloseAfterUse", false);
     }
@@ -325,6 +450,10 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
                     }
                     if ("isClosed".equals(methodName)) {
                         return false;
+                    }
+                    if ("setReadOnly".equals(methodName) || "setAutoCommit".equals(methodName)) {
+                        log.debug("Ignored BIRT attempt to call {} on the read-only report connection.", methodName);
+                        return null;
                     }
                     try {
                         return method.invoke(connection, args);
@@ -355,12 +484,27 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
         final Map<String, String> params = new HashMap<>();
         queryParams.keySet().stream().filter(key -> key.startsWith("R_")).forEach(key -> {
             final String parameterName = key.substring(2);
+            rejectServerManagedParameter(parameterName);
             final String value = queryParams.getFirst(key);
             if (StringUtils.isNotBlank(value)) {
                 params.put(parameterName, value);
             }
         });
         return params;
+    }
+
+    /**
+     * Rejects a request that tries to supply a parameter the server derives from the authenticated
+     * user. Dropping such a value silently would leave the caller believing the scope they asked for
+     * was applied, so the request fails instead.
+     */
+    private void rejectServerManagedParameter(String parameterName) {
+        if (BirtParameterMapper.SERVER_MANAGED_PARAMETERS.contains(parameterName.toLowerCase(Locale.ROOT))) {
+            throw new PlatformDataIntegrityException(
+                    "error.msg.reporting.parameter.not.allowed",
+                    "Parameter '" + parameterName
+                            + "' is derived from the authenticated user and cannot be supplied by the client.");
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/ReportSecurityService.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/ReportSecurityService.java
@@ -7,60 +7,38 @@
  */
 package org.apache.fineract.infrastructure.report.service;
 
-import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ReportSecurityService {
 
-    /**
-     * Apache Fineract permission required to execute reports.
-     */
-    private static final String ALL_FUNCTIONS = "ALL_FUNCTIONS";
-
-    public static final String READ_REPORT_PERMISSION = "READ_REPORT";
-
-    private static final String ERROR_CODE = "error.msg.reporting.permission.denied";
+    private final PlatformSecurityContext securityContext;
 
     /**
-     * Verifies that the currently authenticated Apache Fineract user is authorized to read reports.
+     * Verifies that the authenticated Apache Fineract user is granted the report that is about to be
+     * executed.
      *
-     * <p>The check is deliberately performed before report loading, BIRT execution, datasource
-     * access, and SQL execution.
+     * <p>The user is taken from {@link PlatformSecurityContext}, never from the request, and the
+     * grants are the ones Apache Fineract itself requires to run a report ({@code READ_<reportName>},
+     * {@code REPORTING_SUPER_USER}, {@code ALL_FUNCTIONS} or {@code ALL_FUNCTIONS_READ}).
      *
-     * @throws PlatformDataIntegrityException when the authenticated user does not have
-     *         {@code READ_REPORT}
+     * <p>The check is deliberately performed inside {@code processRequest}, before report loading,
+     * BIRT execution and SQL execution, because that is the only point every caller passes through:
+     * the {@code /runreports} resource checks the grant itself, but the report mailing job does not.
+     *
+     * @throws NoAuthorizationException when the authenticated user is not granted the report
      */
-    public void checkReadReportPermission() {
+    public void checkReportExecutionPermission(final String reportName) {
 
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        final AppUser currentUser = securityContext.authenticatedUser();
 
-        if (!isAuthenticated(authentication)) {
-            throw new PlatformDataIntegrityException(
-                    ERROR_CODE, "The authenticated user is not authorized to execute reports.");
+        if (currentUser.hasNotPermissionForReport(reportName)) {
+            throw new NoAuthorizationException("Not authorised to run report: " + reportName);
         }
-
-        if (!hasReadReportPermission(authentication)) {
-            throw new PlatformDataIntegrityException(
-                    ERROR_CODE, "The authenticated user does not have the READ_REPORT permission.");
-        }
-    }
-
-    private boolean isAuthenticated(Authentication authentication) {
-
-        return authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() != null;
-    }
-
-    private boolean hasReadReportPermission(Authentication authentication) {
-        final var authorities = authentication.getAuthorities();
-        if (authorities == null) {
-            return false;
-        }
-        return authorities.stream().anyMatch(authority -> {
-            final String granted = authority.getAuthority();
-            return READ_REPORT_PERMISSION.equals(granted) || ALL_FUNCTIONS.equals(granted);
-        });
     }
 }

--- a/src/test/java/org/apache/fineract/infrastructure/report/ShippedReportDesignTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/ShippedReportDesignTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards the SQL that ships with the plugin.
+ *
+ * <p>Report SQL runs on a read-only connection, so a shipped report cannot damage the database. What
+ * these tests protect is the other half: that the shipped designs keep binding their values as
+ * parameters instead of pasting them into the query, and that they keep filtering on the caller's
+ * office hierarchy — neither of which the execution boundary can impose on a report design.
+ */
+@DisplayName("Shipped .rptdesign files")
+class ShippedReportDesignTest {
+
+    private static final Path REPORTS_DIRECTORY = Paths.get("birt", "reports");
+
+    private static final Pattern QUERY_TEXT =
+            Pattern.compile("<xml-property name=\"queryText\"><!\\[CDATA\\[(.*?)]]></xml-property>", Pattern.DOTALL);
+
+    static Stream<Path> shippedReports() throws IOException {
+        try (Stream<Path> files = Files.list(REPORTS_DIRECTORY)) {
+            return files.filter(path -> path.toString().endsWith(".rptdesign")).toList().stream();
+        }
+    }
+
+    @Test
+    @DisplayName("are present, so the checks below are not silently vacuous")
+    void reportsArePresent() throws IOException {
+        assertThat(shippedReports()).isNotEmpty();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shippedReports")
+    @DisplayName("build every query from bound parameters, never string interpolation")
+    void queriesAreParameterised(Path report) {
+        final String design = read(report);
+
+        assertThat(queriesOf(design)).as("no dataset query found in %s", report).isNotEmpty();
+
+        for (String query : queriesOf(design)) {
+            assertThat(query)
+                    .as("query in %s interpolates a value into the SQL text", report)
+                    .doesNotContain("${");
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shippedReports")
+    @DisplayName("do not rewrite their query at run time from a script")
+    void queriesAreNotBuiltByScripts(Path report) {
+        final String design = read(report);
+
+        assertThat(design)
+                .as(
+                        "a script in %s assigns queryText, which would make the executed SQL "
+                                + "invisible to any design-time inspection",
+                        report)
+                .doesNotContain("this.queryText")
+                .doesNotContain("setQueryText");
+    }
+
+    @Test
+    @DisplayName("Active_Loans_Details scopes its result set to the caller's office hierarchy")
+    void activeLoansDetailsBindsTheUserHierarchy() {
+        final String design = read(REPORTS_DIRECTORY.resolve("Active_Loans_Details.rptdesign"));
+
+        assertThat(design)
+                .as("userhierarchy must stay a declared report parameter for the server to inject it")
+                .contains("<scalar-parameter name=\"userhierarchy\"");
+
+        assertThat(design)
+                .as("userhierarchy must stay bound as the dataset's first parameter")
+                .containsPattern(Pattern.compile(
+                        "<property name=\"paramName\">userhierarchy</property>.*?"
+                                + "<property name=\"position\">1</property>",
+                        Pattern.DOTALL));
+
+        final String query = queriesOf(design).get(0);
+        assertThat(query)
+                .as("the hierarchy filter must be a bind, not a literal")
+                .contains("ounder.hierarchy LIKE CONCAT(?, '%')");
+    }
+
+    /**
+     * A tripwire, not a preference. Rejecting SQL comments is a recurring proposal for hardening
+     * report SQL; it would break this report on the day it is introduced, and rejecting comments
+     * stops no read-based injection anyway.
+     */
+    @Test
+    @DisplayName("Active_Loans_Details contains an SQL comment, so comment rejection would break it")
+    void activeLoansDetailsContainsAnSqlComment() {
+        final String query = queriesOf(read(REPORTS_DIRECTORY.resolve("Active_Loans_Details.rptdesign")))
+                .get(0);
+
+        assertThat(query).contains("-- Param 2: branch");
+    }
+
+    private List<String> queriesOf(String design) {
+        final List<String> queries = new ArrayList<>();
+        final Matcher matcher = QUERY_TEXT.matcher(design);
+        while (matcher.find()) {
+            queries.add(matcher.group(1));
+        }
+        return queries;
+    }
+
+    private String read(Path report) {
+        try {
+            return Files.readString(report, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtConnectionReadOnlyIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtConnectionReadOnlyIntegrationTest.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Establishes what the JDBC connection BIRT executes a report's SQL on is actually allowed to do.
+ *
+ * <p>{@code BirtReportingProcessServiceImpl} runs every report inside a {@link TransactionTemplate}
+ * marked read-only. These tests answer, against a real database and Apache Fineract's own
+ * transaction manager, two questions that decide how the SQL embedded in a {@code .rptdesign} file
+ * has to be contained:
+ *
+ * <ol>
+ *   <li>does the transaction's read-only marker reach the JDBC connection? (it does not)
+ *   <li>does the connection the service opens for BIRT make the database refuse the writes a report
+ *       can issue? (it does, up to the boundary the last test records)
+ * </ol>
+ *
+ * <p>This is why the plugin contains no SQL pattern matching: the report's SQL is never inspected,
+ * it is executed somewhere ordinary writes fail. Report scripts can rewrite a query at run time, so
+ * inspecting the design would not be sound anyway — and the one sequence that still gets through
+ * would not be caught by a blacklist that a script can evade either.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("BIRT JDBC connection read-only behaviour")
+public class BirtConnectionReadOnlyIntegrationTest {
+
+    private static final String READ_ONLY_USER = "birt_ro";
+
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("birt_readonly_probe")
+            .withUsername("postgres")
+            .withPassword("postgres");
+
+    private HikariDataSource dataSource;
+    private LocalContainerEntityManagerFactoryBean entityManagerFactoryBean;
+    private ExtendedJpaTransactionManager transactionManager;
+
+    @BeforeAll
+    void startDatabase() throws SQLException {
+        POSTGRES.start();
+
+        dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(POSTGRES.getJdbcUrl());
+        dataSource.setUsername(POSTGRES.getUsername());
+        dataSource.setPassword(POSTGRES.getPassword());
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setMaximumPoolSize(4);
+
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE probe (id INT PRIMARY KEY, note TEXT)");
+            statement.execute("INSERT INTO probe VALUES (1, 'seed')");
+            statement.execute("CREATE ROLE " + READ_ONLY_USER + " LOGIN PASSWORD '" + READ_ONLY_USER + "'");
+            statement.execute("GRANT CONNECT ON DATABASE " + POSTGRES.getDatabaseName() + " TO " + READ_ONLY_USER);
+            statement.execute("GRANT USAGE ON SCHEMA public TO " + READ_ONLY_USER);
+            statement.execute("GRANT SELECT ON ALL TABLES IN SCHEMA public TO " + READ_ONLY_USER);
+        }
+
+        entityManagerFactoryBean = buildEntityManagerFactory(dataSource);
+        // false = the read-write manager, which is the one a report request runs under
+        transactionManager = new ExtendedJpaTransactionManager(false);
+        transactionManager.setEntityManagerFactory(entityManagerFactoryBean.getObject());
+        transactionManager.setDataSource(dataSource);
+        transactionManager.afterPropertiesSet();
+    }
+
+    @AfterAll
+    void stopDatabase() {
+        if (entityManagerFactoryBean != null) {
+            entityManagerFactoryBean.destroy();
+        }
+        if (dataSource != null) {
+            dataSource.close();
+        }
+        POSTGRES.stop();
+    }
+
+    /**
+     * The premise the guard rests on. Apache Fineract's transaction manager is a
+     * {@code JpaTransactionManager}: it applies read-only to the persistence context, never to the
+     * JDBC connection. Should that ever change, this test fails and the guard becomes redundant
+     * rather than wrong.
+     */
+    @Test
+    @DisplayName("A read-only Spring transaction leaves the JDBC connection writable")
+    void readOnlyTransactionDoesNotRestrictTheJdbcConnection() {
+        final TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+
+        final int rowsBefore = rowCount();
+
+        transactionTemplate.execute(status -> {
+            final Connection connection = DataSourceUtils.getConnection(dataSource);
+            try {
+                assertThat(connection.isReadOnly())
+                        .as("read-only never reaches the connection BIRT would be handed")
+                        .isFalse();
+
+                try (Statement statement = connection.createStatement()) {
+                    statement.execute("INSERT INTO probe VALUES (2, 'written in a read-only transaction')");
+                }
+            } catch (SQLException e) {
+                throw new IllegalStateException(e);
+            } finally {
+                DataSourceUtils.releaseConnection(connection, dataSource);
+            }
+            return null;
+        });
+
+        assertThat(rowCount())
+                .as("the write went through, so the transaction offered no protection")
+                .isEqualTo(rowsBefore + 1);
+    }
+
+    @Test
+    @DisplayName("The connection opened for BIRT lets the database reject every write")
+    void readOnlyConnectionRejectsWrites() {
+        assertRejected("INSERT INTO probe VALUES (99, 'injected')", "cannot execute INSERT in a read-only transaction");
+        assertRejected("UPDATE probe SET note = 'tampered' WHERE id = 1", "cannot execute UPDATE");
+        assertRejected("DELETE FROM probe", "cannot execute DELETE");
+        assertRejected("CREATE TABLE injected (id INT)", "cannot execute CREATE TABLE");
+    }
+
+    /**
+     * The property that makes the guard hold against hostile SQL rather than merely against honest
+     * mistakes. A statement inside the report cannot hand itself write access back, because the
+     * connection is opened with a query of our own and a database only pins read-only mode once the
+     * transaction has taken its snapshot.
+     */
+    @Test
+    @DisplayName("SQL inside the report cannot lift the read-only state")
+    void readOnlyStateCannotBeLiftedBySql() {
+        assertRejected("SET TRANSACTION READ WRITE", "must be set before any query");
+        assertRejected("SELECT 1; INSERT INTO probe VALUES (98, 'stacked')", "cannot execute INSERT");
+    }
+
+    /** A report that commits, or changes the session default, still gets a read-only transaction. */
+    @Test
+    @DisplayName("Ending the transaction from SQL does not buy write access")
+    void readOnlyStateSurvivesCommit() throws SQLException {
+        try (Connection connection = openReadOnlyConnection()) {
+            execute(connection, "SET default_transaction_read_only = off");
+            execute(connection, "COMMIT");
+            assertThatThrownBy(() -> execute(connection, "INSERT INTO probe VALUES (97, 'after commit')"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("read-only transaction");
+            connection.rollback();
+        }
+    }
+
+    /**
+     * The guard must not follow the connection back into the pool. Fineract writes through the same
+     * pool, so a restriction left behind on a returned connection would break the next thing that
+     * borrowed it — which is why the transaction, not the session, is what gets marked read-only.
+     */
+    @Test
+    @DisplayName("A connection handed back to the pool is writable again")
+    void poolConnectionIsNotLeftReadOnly() throws SQLException {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            try (Connection connection = openReadOnlyConnection()) {
+                connection.rollback();
+            }
+
+            try (Connection connection = dataSource.getConnection();
+                    Statement statement = connection.createStatement()) {
+                assertThat(connection.isReadOnly()).isFalse();
+                statement.execute("INSERT INTO probe VALUES (90, 'pool still writable')");
+                statement.execute("DELETE FROM probe WHERE id = 90");
+            }
+        }
+    }
+
+    /**
+     * The boundary a report cannot argue with, and the reason the tenant's read-only principal is
+     * worth configuring: the same escape sequence that defeats the read-only transaction is refused
+     * outright for a principal that was never granted the write.
+     */
+    @Test
+    @DisplayName("A SELECT-only principal refuses the escape the read-only transaction cannot")
+    void selectOnlyPrincipalRefusesTheEscape() throws SQLException {
+        final int rowsBefore = rowCount();
+
+        // the same sequence that defeats the read-only transaction, plus the writes it does catch
+        assertRefusedForSelectOnlyPrincipal(
+                "START TRANSACTION READ WRITE; INSERT INTO probe VALUES (94, 'escaped'); COMMIT");
+        assertRefusedForSelectOnlyPrincipal("INSERT INTO probe VALUES (93, 'plain')");
+        assertRefusedForSelectOnlyPrincipal("CREATE TABLE injected (id INT)");
+        assertRefusedForSelectOnlyPrincipal("SET ROLE postgres");
+
+        assertThat(rowCount()).isEqualTo(rowsBefore);
+    }
+
+    @Test
+    @DisplayName("A SELECT-only principal still serves the report's reads")
+    void selectOnlyPrincipalStillReads() throws SQLException {
+        try (Connection connection =
+                        DriverManager.getConnection(POSTGRES.getJdbcUrl(), READ_ONLY_USER, READ_ONLY_USER);
+                PreparedStatement statement = connection.prepareStatement("SELECT note FROM probe WHERE id = ?")) {
+            statement.setInt(1, 1);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getString(1)).isEqualTo("seed");
+            }
+        }
+    }
+
+    /**
+     * Records the boundary of the guard rather than leaving it to be discovered.
+     *
+     * <p>A report that opens a transaction of its own is no longer in the read-only one, and writes.
+     * Nothing at the connection can prevent that — the statement is legal SQL and refusing it would
+     * mean pattern matching the report's SQL, which does not survive scripts building queries at run
+     * time. The answer to a hostile {@code .rptdesign} is a database user without write privileges,
+     * plus keeping report installation an administrative operation.
+     *
+     * <p>If this test ever fails, the guard has become stronger than documented — check what changed
+     * before relaxing the wording elsewhere.
+     */
+    @Test
+    @DisplayName("Known limitation: a report that starts its own read-write transaction can write")
+    void reportCanEscapeByStartingItsOwnTransaction() throws SQLException {
+        final int rowsBefore = rowCount();
+
+        try (Connection connection = openReadOnlyConnection()) {
+            execute(connection, "COMMIT");
+            execute(connection, "START TRANSACTION READ WRITE");
+            execute(connection, "INSERT INTO probe VALUES (96, 'escaped')");
+            execute(connection, "COMMIT");
+        }
+
+        assertThat(rowCount())
+                .as("the escape is real; containment needs a read-only database user")
+                .isEqualTo(rowsBefore + 1);
+    }
+
+    @Test
+    @DisplayName("A read-only connection still serves the SELECT a report needs")
+    void readOnlyConnectionStillReads() throws SQLException {
+        try (Connection connection = openReadOnlyConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT note FROM probe WHERE id = ?")) {
+            statement.setInt(1, 1);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getString(1)).isEqualTo("seed");
+            }
+            connection.rollback();
+        }
+    }
+
+    /** Mirrors {@code BirtReportingProcessServiceImpl#openReadOnlyConnection}. */
+    private Connection openReadOnlyConnection() throws SQLException {
+        final Connection connection = dataSource.getConnection();
+        connection.setReadOnly(true);
+        connection.setAutoCommit(false);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 1");
+        }
+        return connection;
+    }
+
+    /**
+     * Each statement gets its own connection: the first refusal aborts the transaction, so reusing
+     * one would report "current transaction is aborted" for everything after it.
+     */
+    private void assertRejected(String sql, String expectedMessage) {
+        assertThatThrownBy(() -> {
+                    try (Connection connection = openReadOnlyConnection()) {
+                        execute(connection, sql);
+                    }
+                })
+                .as("the database should refuse: %s", sql)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
+    /** Fresh connection per statement: the first refusal aborts the transaction for the rest. */
+    private void assertRefusedForSelectOnlyPrincipal(String sql) {
+        assertThatThrownBy(() -> {
+                    try (Connection connection =
+                                    DriverManager.getConnection(POSTGRES.getJdbcUrl(), READ_ONLY_USER, READ_ONLY_USER);
+                            Statement statement = connection.createStatement()) {
+                        statement.execute(sql);
+                    }
+                })
+                .as("a SELECT-only principal should be refused: %s", sql)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("permission denied");
+    }
+
+    private void execute(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    private int rowCount() {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM probe")) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static LocalContainerEntityManagerFactoryBean buildEntityManagerFactory(HikariDataSource dataSource) {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("eclipselink.weaving", "false");
+        properties.put("eclipselink.ddl-generation", "none");
+        properties.put("eclipselink.logging.level", "OFF");
+
+        final LocalContainerEntityManagerFactoryBean bean = new LocalContainerEntityManagerFactoryBean();
+        bean.setDataSource(dataSource);
+        bean.setPersistenceUnitName("birt-readonly-probe");
+        bean.setPackagesToScan("org.apache.fineract.infrastructure.report.integration.noentities");
+        bean.setJpaVendorAdapter(new EclipseLinkJpaVendorAdapter());
+        bean.setJpaPropertyMap(properties);
+        bean.afterPropertiesSet();
+        return bean;
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtMigrationPipelineIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtMigrationPipelineIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.apache.fineract.infrastructure.report.service.BirtParameterMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -103,13 +104,20 @@ public class BirtMigrationPipelineIntegrationTest extends BirtIntegrationTestBas
             String pName = m.group(1);
             String lowerName = pName.toLowerCase();
 
+            /*
+             * userid and userhierarchy are injected from the authenticated
+             * user, and a request that supplies them is now rejected. Sending
+             * them here would ask the server for a scope the caller chose.
+             */
+            if (BirtParameterMapper.SERVER_MANAGED_PARAMETERS.contains(lowerName)) {
+                continue;
+            }
+
             String value;
             if (lowerName.contains("date")) {
                 value = "01 January 2010";
             } else if (lowerName.contains("url")) {
                 value = "https://localhost";
-            } else if (lowerName.contains("hierarchy")) {
-                value = ".";
             } else if (lowerName.contains("officer")
                     || lowerName.contains("purpose")
                     || lowerName.contains("product")

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtReadOnlyPrincipalIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtReadOnlyPrincipalIntegrationTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+
+/**
+ * Runs a shipped report end to end with the tenant's read-only database principal configured, the
+ * arrangement that actually contains a hostile {@code .rptdesign}.
+ *
+ * <p>Point of the test: a principal granted only {@code SELECT} is worthless if BIRT cannot render
+ * through it. This checks the report still comes back, that the plugin really connected as that
+ * principal, and that the principal is one the database refuses writes from.
+ */
+@DisplayName("BIRT execution as the tenant's read-only principal")
+public class BirtReadOnlyPrincipalIntegrationTest extends BirtIntegrationTestBase {
+
+    private static final String READ_ONLY_USER = "birt_ro";
+
+    /**
+     * {@code readonly_schema_password} is decrypted exactly like {@code schema_password}, so it has
+     * to be stored the same way — a plaintext value there fails to decrypt and the report fails
+     * closed. The role therefore gets the tenant's own database password and the column gets the
+     * tenant's existing encrypted blob, which keeps the test free of the master password.
+     */
+    @BeforeAll
+    void configureReadOnlyPrincipal() {
+        run(
+                "fineract_default",
+                "CREATE ROLE " + READ_ONLY_USER + " LOGIN PASSWORD 'postgres';"
+                        + "GRANT CONNECT ON DATABASE fineract_default TO " + READ_ONLY_USER + ";"
+                        + "GRANT USAGE ON SCHEMA public TO " + READ_ONLY_USER + ";"
+                        + "GRANT SELECT ON ALL TABLES IN SCHEMA public TO " + READ_ONLY_USER + ";");
+
+        run(
+                "fineract_tenants",
+                "UPDATE tenant_server_connections SET readonly_schema_server = 'db',"
+                        + " readonly_schema_server_port = '5432',"
+                        + " readonly_schema_name = 'fineract_default',"
+                        + " readonly_schema_username = '" + READ_ONLY_USER + "',"
+                        + " readonly_schema_password = schema_password;");
+    }
+
+    @Test
+    @DisplayName("Should render a shipped report through the SELECT-only principal")
+    void shouldRenderReportAsReadOnlyPrincipal() {
+        given().spec(requestSpec())
+                .header("Fineract-Platform-TenantId", "default")
+                .header("Authorization", "Basic bWlmb3M6cGFzc3dvcmQ=")
+                .queryParam("tenantIdentifier", "default")
+                .queryParam("output-type", "CSV")
+                .queryParam("locale", "en")
+                .queryParam("dateFormat", "dd MMMM yyyy")
+                .queryParam("R_branch", "1")
+                .queryParam("R_loanOfficer", "-1")
+                .queryParam("R_loanPurposeId", "-1")
+                .queryParam("R_loanProductId", "-1")
+                .queryParam("R_fundId", "-1")
+                .queryParam("R_currencyId", "-1")
+                .when()
+                .get("/fineract-provider/api/v1/runreports/Active_Loans_Details")
+                .then()
+                .statusCode(200)
+                .contentType("text/csv");
+    }
+
+    /** Proves the principal the report ran as is genuinely unable to write. */
+    @Test
+    @DisplayName("The configured principal is refused every write by the database")
+    void configuredPrincipalCannotWrite() {
+        final Container.ExecResult result = execPostgres(
+                "psql",
+                "-U",
+                READ_ONLY_USER,
+                "-d",
+                "fineract_default",
+                "-c",
+                "INSERT INTO m_office (id, name, hierarchy, opening_date) VALUES (999, 'evil', '.', now())");
+
+        assertThat(result.getStderr()).contains("permission denied");
+    }
+
+    private RequestSpecification requestSpec() {
+        return new RequestSpecBuilder()
+                .setBaseUri("https://" + FINERACT.getHost() + ":" + getFineractPort())
+                .setRelaxedHTTPSValidation()
+                .build();
+    }
+
+    private void run(String database, String sql) {
+        final Container.ExecResult result = execPostgres("psql", "-U", "postgres", "-d", database, "-c", sql);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException("Setup SQL failed: " + result.getStderr());
+        }
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportLoaderTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportLoaderTest.java
@@ -7,10 +7,13 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
@@ -95,5 +98,43 @@ class BirtReportLoaderTest {
 
         IReportRunnable report = reportLoader.loadReport("sample", java.util.Locale.forLanguageTag("es"));
         assertNotNull(report);
+    }
+
+    @Test
+    @DisplayName("Should reject a report name that climbs out of the reports directory")
+    void shouldRejectReportNameEscapingTheReportsDirectory() throws Exception {
+        Path outside = tempDir.getParent().resolve("outside.rptdesign");
+        Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("../outside", null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+        verify(reportEngine, never()).openReportDesign(anyString());
+    }
+
+    @Test
+    @DisplayName("Should reject an absolute report name")
+    void shouldRejectAbsoluteReportName() throws Exception {
+        Path outside = tempDir.getParent().resolve("absolute.rptdesign");
+        Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
+
+        String absoluteName = outside.toString().replace(".rptdesign", "");
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport(absoluteName, null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+        verify(reportEngine, never()).openReportDesign(anyString());
+    }
+
+    @Test
+    @DisplayName("Should not disclose the server filesystem path when a report is missing")
+    void shouldNotLeakFilesystemPathWhenReportIsMissing() {
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("missing", null));
+
+        assertFalse(ex.getDefaultUserMessage().contains(tempDir.toString()));
+        assertFalse(ex.getDefaultUserMessage().contains(".rptdesign"));
     }
 }

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
@@ -8,6 +8,7 @@ package org.apache.fineract.infrastructure.report.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,9 +16,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +29,8 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +54,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
@@ -113,11 +118,11 @@ class BirtReportingProcessServiceImplTest {
     @InjectMocks
     private BirtReportingProcessServiceImpl service;
 
-    private MockedStatic<DataSourceUtils> mockedDataSourceUtils;
     private MockedStatic<ThreadLocalContextUtil> mockedThreadLocalContextUtil;
     private MockedStatic<org.apache.fineract.infrastructure.report.util.DataSourceUtils> mockedReportDataSourceUtils;
 
     private Connection mockConnection;
+    private FineractPlatformTenantConnection tenantConnection;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -137,18 +142,12 @@ class BirtReportingProcessServiceImplTest {
         DatabaseMetaData metaData = mock(DatabaseMetaData.class);
         lenient().when(mockConnection.getMetaData()).thenReturn(metaData);
         lenient().when(metaData.getURL()).thenReturn("jdbc:postgresql://localhost:5432/fineract_tenant");
-
-        mockedDataSourceUtils = mockStatic(DataSourceUtils.class);
-        mockedDataSourceUtils
-                .when(() -> DataSourceUtils.getConnection(any(DataSource.class)))
-                .thenReturn(mockConnection);
-        mockedDataSourceUtils
-                .when(() -> DataSourceUtils.releaseConnection(any(Connection.class), any(DataSource.class)))
-                .thenAnswer(i -> null);
+        lenient().when(mockConnection.createStatement()).thenReturn(mock(Statement.class));
+        lenient().when(dataSource.getConnection()).thenReturn(mockConnection);
 
         // Mock Tenant Context
         FineractPlatformTenant tenant = mock(FineractPlatformTenant.class);
-        FineractPlatformTenantConnection tenantConnection = mock(FineractPlatformTenantConnection.class);
+        tenantConnection = mock(FineractPlatformTenantConnection.class);
         lenient().when(tenant.getConnection()).thenReturn(tenantConnection);
         lenient().when(tenant.getTenantIdentifier()).thenReturn("default");
         lenient().when(tenantConnection.getSchemaUsername()).thenReturn("tenant_user");
@@ -166,9 +165,6 @@ class BirtReportingProcessServiceImplTest {
 
     @AfterEach
     void tearDown() {
-        if (mockedDataSourceUtils != null) {
-            mockedDataSourceUtils.close();
-        }
         if (mockedThreadLocalContextUtil != null) {
             mockedThreadLocalContextUtil.close();
         }
@@ -325,8 +321,14 @@ class BirtReportingProcessServiceImplTest {
         // Verify the setConnectionDetail logic successfully populated the appContext
         assertEquals("org.postgresql.Driver", appContext.get("OdaJDBCDriverClass"));
         assertEquals("jdbc:postgresql://localhost:5432/fineract_tenant", appContext.get("OdaJDBCDriverUrl"));
-        assertEquals("tenant_user", appContext.get("OdaJDBCDriverUser"));
-        assertEquals("decrypted_pass", appContext.get("OdaJDBCDriverPassword"));
+
+        /*
+         * No credentials: BIRT takes the pass-in connection and returns before
+         * reading a user or password, so publishing them would only expose the
+         * tenant's decrypted database password to report scripts.
+         */
+        assertNull(appContext.get("OdaJDBCDriverUser"));
+        assertNull(appContext.get("OdaJDBCDriverPassword"));
 
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(
                 reportExecutionFactory, sqlDialectInterpolator, parameterMapper, contextInjector, task, pdfRenderer);
@@ -412,6 +414,172 @@ class BirtReportingProcessServiceImplTest {
         assertThrows(PlatformDataIntegrityException.class, () -> service.processRequest("sample", queryParams("PDF")));
 
         verify(task).close();
+    }
+
+    @Test
+    @DisplayName("Should reject a client-supplied userid instead of dropping it silently")
+    void shouldRejectClientSuppliedUserId() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("R_userid", "1");
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> service.getReportParams("sample", params));
+
+        assertEquals("error.msg.reporting.parameter.not.allowed", ex.getGlobalisationMessageCode());
+    }
+
+    @Test
+    @DisplayName("Should reject a client-supplied userhierarchy whatever its casing")
+    void shouldRejectClientSuppliedUserHierarchy() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("R_userHierarchy", ".");
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> service.getReportParams("sample", params));
+
+        assertEquals("error.msg.reporting.parameter.not.allowed", ex.getGlobalisationMessageCode());
+    }
+
+    @Test
+    @DisplayName("Should verify the report grant before anything is loaded or executed")
+    void shouldCheckPermissionBeforeExecuting() {
+        doThrow(new PlatformDataIntegrityException("error.denied", "denied"))
+                .when(reportSecurityService)
+                .checkReportExecutionPermission("sample");
+
+        assertThrows(PlatformDataIntegrityException.class, () -> service.processRequest("sample", queryParams("PDF")));
+
+        verify(reportExecutionFactory, never()).createExecutionRunnable(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("Should hand BIRT a connection the database will not accept writes on")
+    void shouldGiveBirtAReadOnlyConnection() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+        HashMap<String, Object> appContext = new HashMap<>();
+        Statement statement = mock(Statement.class);
+
+        when(mockConnection.createStatement()).thenReturn(statement);
+        when(task.getAppContext()).thenReturn(appContext);
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        when(pdfRenderer.render(eq(reportEngine), anyString(), anyString()))
+                .thenReturn(Response.ok().type("application/pdf").build());
+
+        service.processRequest("sample", queryParams("PDF"));
+
+        InOrder inOrder = inOrder(mockConnection, statement, task);
+        inOrder.verify(mockConnection).setReadOnly(true);
+        inOrder.verify(mockConnection).setAutoCommit(false);
+        // pins the read-only state: a database stops accepting READ WRITE once a query has run
+        inOrder.verify(statement).execute("SELECT 1");
+        inOrder.verify(task).run(anyString());
+
+        verify(mockConnection).close();
+        // PostgreSQL's driver opens the transaction read-only by itself
+        verify(statement, never()).execute("START TRANSACTION READ ONLY");
+    }
+
+    @Test
+    @DisplayName("Should open the read-only transaction explicitly on MySQL/MariaDB")
+    void shouldStartReadOnlyTransactionExplicitlyOnMariaDb() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+        HashMap<String, Object> appContext = new HashMap<>();
+        Statement statement = mock(Statement.class);
+
+        when(mockConnection.getMetaData().getURL()).thenReturn("jdbc:mariadb://localhost:3306/fineract_tenant");
+        when(mockConnection.createStatement()).thenReturn(statement);
+        when(task.getAppContext()).thenReturn(appContext);
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        when(pdfRenderer.render(eq(reportEngine), anyString(), anyString()))
+                .thenReturn(Response.ok().type("application/pdf").build());
+
+        service.processRequest("sample", queryParams("PDF"));
+
+        InOrder inOrder = inOrder(mockConnection, statement);
+        inOrder.verify(mockConnection).setAutoCommit(false);
+        // MariaDB's driver treats setReadOnly as a routing hint, so the transaction is opened by hand
+        inOrder.verify(statement).execute("START TRANSACTION READ ONLY");
+        inOrder.verify(statement).execute("SELECT 1");
+    }
+
+    @Test
+    @DisplayName("Should apply the server-derived user context after the client parameters")
+    void shouldInjectServerContextAfterClientParameters() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+        HashMap<String, Object> appContext = new HashMap<>();
+
+        when(task.getAppContext()).thenReturn(appContext);
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        when(pdfRenderer.render(eq(reportEngine), anyString(), anyString()))
+                .thenReturn(Response.ok().type("application/pdf").build());
+
+        service.processRequest("sample", queryParams("PDF"));
+
+        InOrder inOrder = inOrder(parameterMapper, contextInjector, task);
+        inOrder.verify(parameterMapper).applyParameters(eq(task), any());
+        inOrder.verify(contextInjector).injectContextParameters(task);
+        inOrder.verify(task).run(anyString());
+    }
+
+    @Test
+    @DisplayName("Should run reports as the tenant's read-only principal when one is configured")
+    void shouldUseReadOnlyPrincipalWhenConfigured() throws Exception {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("encrypted_ro ");
+        when(tenantConnection.getReadOnlySchemaServer()).thenReturn("replica");
+        when(tenantConnection.getReadOnlySchemaServerPort()).thenReturn("5432");
+        when(tenantConnection.getReadOnlySchemaName()).thenReturn("fineract_default");
+        when(databasePasswordEncryptor.decrypt("encrypted_ro")).thenReturn("ro_pass");
+
+        try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class)) {
+            driverManager
+                    .when(() -> DriverManager.getConnection(anyString(), anyString(), anyString()))
+                    .thenReturn(mockConnection);
+
+            runReport();
+
+            driverManager.verify(() -> DriverManager.getConnection(
+                    "jdbc:postgresql://replica:5432/fineract_default", "birt_ro", "ro_pass"));
+        }
+        verify(dataSource, never()).getConnection();
+    }
+
+    @Test
+    @DisplayName("Should fall back to the tenant pool when no read-only principal is configured")
+    void shouldFallBackToTenantPoolWhenNoReadOnlyPrincipal() throws Exception {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("");
+
+        runReport();
+
+        verify(dataSource).getConnection();
+    }
+
+    /** Drives one successful PDF report execution with the common BIRT mocks in place. */
+    private void runReport() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+
+        when(task.getAppContext()).thenReturn(new HashMap<>());
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        when(pdfRenderer.render(eq(reportEngine), anyString(), anyString()))
+                .thenReturn(Response.ok().type("application/pdf").build());
+
+        service.processRequest("sample", queryParams("PDF"));
     }
 
     private BirtRenderer getRendererForType(String outputType) {

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/ReportSecurityServiceTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/ReportSecurityServiceTest.java
@@ -9,203 +9,69 @@ package org.apache.fineract.infrastructure.report.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
-import org.junit.jupiter.api.AfterEach;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReportSecurityService Tests")
 class ReportSecurityServiceTest {
 
+    private static final String REPORT_NAME = "Active_Loans_Details";
+
+    @Mock
+    private PlatformSecurityContext securityContext;
+
+    @Mock
+    private AppUser authenticatedUser;
+
+    @InjectMocks
     private ReportSecurityService reportSecurityService;
 
     @BeforeEach
     void setUp() {
-        reportSecurityService = new ReportSecurityService();
-        SecurityContextHolder.clearContext();
-    }
-
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
+        when(securityContext.authenticatedUser()).thenReturn(authenticatedUser);
     }
 
     @Test
-    @DisplayName("Should allow report execution when user has READ_REPORT permission")
-    void shouldAllowReportExecutionWhenUserHasReadReportPermission() {
+    @DisplayName("Should allow execution when the authenticated user is granted the report")
+    void shouldAllowExecutionWhenUserIsGrantedTheReport() {
+        when(authenticatedUser.hasNotPermissionForReport(REPORT_NAME)).thenReturn(false);
 
-        Authentication authentication = authenticatedUser(
-                "report-user", List.of(new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION)));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
+        assertThatCode(() -> reportSecurityService.checkReportExecutionPermission(REPORT_NAME))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    @DisplayName("Should reject report execution when user does not have READ_REPORT permission")
-    void shouldRejectReportExecutionWhenUserDoesNotHaveReadReportPermission() {
+    @DisplayName("Should reject execution when the authenticated user is not granted the report")
+    void shouldRejectExecutionWhenUserIsNotGrantedTheReport() {
+        when(authenticatedUser.hasNotPermissionForReport(REPORT_NAME)).thenReturn(true);
 
-        Authentication authentication = authenticatedUser(
-                "normal-user",
-                List.of(new SimpleGrantedAuthority("READ_CLIENT"), new SimpleGrantedAuthority("READ_LOAN")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
+        assertThatThrownBy(() -> reportSecurityService.checkReportExecutionPermission(REPORT_NAME))
+                .isInstanceOf(NoAuthorizationException.class)
+                .hasMessageContaining(REPORT_NAME);
     }
 
+    /**
+     * The grant is per report, not a blanket "may run reports": a user granted one report must not
+     * reach another by name.
+     */
     @Test
-    @DisplayName("Should reject report execution when authentication is null")
-    void shouldRejectReportExecutionWhenAuthenticationIsNull() {
+    @DisplayName("Should check the grant for the report being executed, not a generic one")
+    void shouldCheckTheGrantForTheRequestedReport() {
+        when(authenticatedUser.hasNotPermissionForReport("Other_Report")).thenReturn(true);
 
-        SecurityContextHolder.clearContext();
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("not authorized");
-    }
-
-    @Test
-    @DisplayName("Should reject report execution when user is not authenticated")
-    void shouldRejectReportExecutionWhenUserIsNotAuthenticated() {
-
-        Authentication authentication = mock(Authentication.class);
-
-        when(authentication.isAuthenticated()).thenReturn(false);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("not authorized");
-    }
-
-    @Test
-    @DisplayName("Should reject report execution when user has no authorities")
-    void shouldRejectReportExecutionWhenUserHasNoAuthorities() {
-
-        Authentication authentication = authenticatedUser("user-without-authorities", List.of());
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
-    }
-
-    @Test
-    @DisplayName("Should allow report execution when READ_REPORT exists among multiple permissions")
-    void shouldAllowReportExecutionWhenReadReportExistsAmongMultiplePermissions() {
-
-        Authentication authentication = authenticatedUser(
-                "report-user",
-                List.of(
-                        new SimpleGrantedAuthority("READ_CLIENT"),
-                        new SimpleGrantedAuthority("READ_LOAN"),
-                        new SimpleGrantedAuthority("READ_SAVINGS"),
-                        new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION),
-                        new SimpleGrantedAuthority("READ_ACCOUNT")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("Should reject similar but incorrect report permissions")
-    void shouldRejectSimilarButIncorrectReportPermissions() {
-
-        Authentication authentication = authenticatedUser(
-                "user",
-                List.of(
-                        new SimpleGrantedAuthority("READ_REPORTS"),
-                        new SimpleGrantedAuthority("REPORT_READ"),
-                        new SimpleGrantedAuthority("WRITE_REPORT")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
-    }
-
-    @Test
-    @DisplayName("Should require exact READ_REPORT permission")
-    void shouldRequireExactReadReportPermission() {
-
-        Authentication authentication = authenticatedUser(
-                "user",
-                List.of(
-                        new SimpleGrantedAuthority("read_report"),
-                        new SimpleGrantedAuthority("READ_REPORTS"),
-                        new SimpleGrantedAuthority("READ_REPORT ")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
-    }
-
-    @Test
-    @DisplayName("Should allow authenticated user with only READ_REPORT permission")
-    void shouldAllowAuthenticatedUserWithOnlyReadReportPermission() {
-
-        Authentication authentication = authenticatedUser(
-                "report-user", List.of(new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION)));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("Should not depend on username when checking READ_REPORT")
-    void shouldNotDependOnUsernameWhenCheckingReadReport() {
-
-        Authentication authentication = authenticatedUser(
-                "any-user", List.of(new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION)));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("Should reject authentication with null authorities")
-    void shouldRejectAuthenticationWithNullAuthorities() {
-
-        Authentication authentication = mock(Authentication.class);
-
-        when(authentication.isAuthenticated()).thenReturn(true);
-
-        when(authentication.getPrincipal()).thenReturn("report-user");
-
-        when(authentication.getAuthorities()).thenReturn(null);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class);
-    }
-
-    private Authentication authenticatedUser(String username, List<SimpleGrantedAuthority> authorities) {
-
-        return new UsernamePasswordAuthenticationToken(username, "password", authorities);
+        assertThatThrownBy(() -> reportSecurityService.checkReportExecutionPermission("Other_Report"))
+                .isInstanceOf(NoAuthorizationException.class)
+                .hasMessageContaining("Other_Report");
     }
 }


### PR DESCRIPTION
## Description

Report SQL embedded in a `.rptdesign` file was executed on an ordinary read-write tenant connection. This PR moves the restriction to where the database enforces it, and closes several smaller gaps around the same execution path.

No new services, DAOs, configuration flags, or dependencies are introduced, and there is no SQL pattern matching — regex blacklists do not stop read-based injection (`OR`, `UNION`, subqueries) and cannot see SQL that a report script builds at run time.

> **Note on process:** I do not have a Jira ticket for this. Happy to file one under `MX` and rename the branch/PR title if that is required before review.

## Key finding: `@Transactional(readOnly = true)` does not make the BIRT JDBC connection read-only

`BirtReportingProcessServiceImpl` already wrapped execution in a `TransactionTemplate` with `setReadOnly(true)`. That flag never reached the connection BIRT executes on.

Verified three ways rather than assumed:

1. **Bytecode of the resolved dependency** (`fineract-core:0.0.1533-3f071ac`): `ExtendedJpaTransactionManager.doBegin` sets only `FlushModeType.COMMIT`; its `LockFreeEclipseLinkJpaDialect` only sets `lazyDatabaseTransaction(true)`. Nothing calls `Connection.setReadOnly` or `DataSourceUtils.prepareConnectionForTransaction`.
2. **Driver probe:** the connection returned by `DataSourceUtils.getConnection(dataSource)` reported `isReadOnly() = false`, `autoCommit = true`, and accepted an `INSERT`.
3. **A permanent regression test**, `BirtConnectionReadOnlyIntegrationTest#readOnlyTransactionDoesNotRestrictTheJdbcConnection`, which asserts the write succeeds inside a read-only `TransactionTemplate`. If Fineract ever changes this, that test fails and the guard here becomes redundant rather than silently wrong.

## What changed

### 1. The report connection is opened in a read-only transaction

`openReadOnlyConnection()` sets the connection read-only, turns off auto-commit, and opens the transaction with a `SELECT 1` of its own.

This blocks writes through the **normal report SQL execution path** — `INSERT`, `UPDATE`, `DELETE` on both PostgreSQL and MySQL/MariaDB, and DDL on PostgreSQL. It is the database refusing the statement, not the plugin trying to recognise one.

Two mechanics are load-bearing and were each wrong on a first attempt:

- **The `SELECT 1` is not decoration.** A database only stops accepting `SET TRANSACTION READ WRITE` once the transaction has taken its snapshot. Without it, a report's first statement could be `SET TRANSACTION READ WRITE` and a later one a write — verified escaping.
- **`Connection.setReadOnly(true)` is a no-op on MySQL/MariaDB**, where the driver treats it as a replica-routing hint and lets every write through. Those need an explicit `START TRANSACTION READ ONLY`.

### 2. Connection-pool poisoning, found and fixed

The first version of the MySQL/MariaDB fix used `SET SESSION TRANSACTION READ ONLY`. **A session-scoped setting survives the connection's return to the Hikari pool**, so every connection the plugin borrowed would have been left read-only for whatever borrowed it next — breaking Fineract's own writes.

Caught by `BirtConnectionReadOnlyIntegrationTest`. Replaced with the transaction-scoped `START TRANSACTION READ ONLY`, and `poolConnectionIsNotLeftReadOnly` now asserts a returned connection is writable again.

### 3. `R_userid` / `R_userhierarchy` are rejected, not dropped

These are derived from the authenticated user by `BirtContextInjector`. Previously a client-supplied value was skipped silently, which leaves the caller believing the scope they asked for was applied. `getReportParams` now fails the request with `error.msg.reporting.parameter.not.allowed` (case-insensitive). This is enforced in `processRequest`, which is the point both callers pass through.

**Behaviour change:** any caller currently passing `R_userhierarchy` or `R_userid` will start getting an error. `BirtMigrationPipelineIntegrationTest` was doing exactly this — it generated a query parameter for every declared scalar parameter, including `R_userhierarchy=.` (root scope). It now skips server-managed parameters.

### 4. Per-report grant checked from the authenticated user

`ReportSecurityService` previously read Spring `SecurityContextHolder` authorities and accepted a generic `READ_REPORT`, which Fineract itself does not consider sufficient to run a given report. It now takes the user from `PlatformSecurityContext.authenticatedUser()` and uses `hasNotPermissionForReport(reportName)` — the same grant set core Fineract requires (`READ_<reportName>`, `REPORTING_SUPER_USER`, `ALL_FUNCTIONS`, `ALL_FUNCTIONS_READ`).

This matters beyond redundancy: `RunreportsApiResource` checks the grant itself, but `ExecuteReportMailingJobsTasklet` calls `processRequest` with **no permission check at all**. Net −24 lines.

### 5. Report name confined to the reports directory

`BirtReportLoader.buildReportPath` concatenated the request-supplied report name into a filesystem path. It now resolves and normalises against the reports directory and rejects anything that escapes it. The absolute server path was also removed from the not-found response.

### 6. Credentials removed from the BIRT app context

`OdaJDBCDriverUser` / `OdaJDBCDriverPassword` were dead config: `org.eclipse.birt.report.data.oda.jdbc.Connection.open()` checks `OdaJDBCDriverPassInConnection` **first and returns immediately**. Publishing them only placed the tenant's *decrypted* database password in a map reachable from report scripts. The end-to-end suite still renders all five formats, which independently confirms they were unused.

## Security boundary, stated plainly

**What this PR guarantees:** the authenticated user's identity and office hierarchy come from server-side context and cannot be supplied or overridden by the client; the per-report grant is checked before anything is loaded or executed; the report name cannot escape the reports directory; error responses carry no filesystem paths; and the connection report SQL runs on refuses writes.

**What it does not:** ⚠️ **a malicious `.rptdesign` is not fully sandboxed.** Two limits, both verified rather than assumed:

- A design that issues its own transaction control — `COMMIT` followed by `START TRANSACTION READ WRITE` — leaves the read-only transaction behind and **can write**. Confirmed persisting a row on both PostgreSQL and MariaDB. This is recorded as a passing test (`reportCanEscapeByStartingItsOwnTransaction`) so the boundary is documented rather than discovered later.
- MySQL/MariaDB do not block DDL in a read-only transaction, because they commit implicitly before it.

Neither is fixable at the connection, and neither would be caught by a SQL blacklist that a report script can evade. There is also no execution-boundary defence against a design whose SQL simply *omits* the `userhierarchy` predicate — that is a property of the report, not of the request.

**`.rptdesign` files therefore remain trusted, administrator-installed artefacts.**

### Database-level SELECT-only credentials are the stronger boundary — and are outside this PR

A database principal granted only `SELECT` is the one boundary a report cannot argue with: it refuses the transaction-control escape above, refuses DDL on every engine, and refuses `SET ROLE`. Verified against a live deployment, where it also runs the shipped `Active_Loans_Details` unchanged.

This PR adds *support* for using one — when a tenant has `readonly_schema_username` set, the report connection is opened as that principal, reusing Fineract's existing `tenant_server_connections.readonly_schema_*` columns so no new configuration surface is introduced. Blank fields fall back to their read-write counterparts.

**Provisioning it is deployment work and is not part of this PR.** It requires an operator to create the restricted role and populate those columns, which are **empty in a stock deployment** — so this is opt-in and off by default, and the read-only transaction remains what protects tenants who have not configured one. Note that `readonly_schema_password` must be stored **encrypted**, exactly like `schema_password`; a plaintext value fails to decrypt and the report fails closed.

## Testing

`./mvnw clean verify` — **108 unit tests and 19 integration tests pass**, spotless clean.

New coverage:
- `BirtConnectionReadOnlyIntegrationTest` (9) — the read-only propagation finding, the guard, escape attempts, pool-return safety, and the documented limitation, against a real PostgreSQL container.
- `BirtReadOnlyPrincipalIntegrationTest` (2) — creates a real `SELECT`-only role, points the tenant at it, renders `Active_Loans_Details` through it, and asserts the same role is refused an `INSERT`.
- `ShippedReportDesignTest` (7) — shipped designs stay parameterised, are not rewritten by scripts, and keep binding `userhierarchy`. Includes a tripwire recording that `Active_Loans_Details` contains an SQL comment (`-- Param 2: branch`), so a future "reject SQL comments" control would break it.
- Path-traversal, path-disclosure, parameter-rejection, grant-check and read-only-principal unit tests.

Existing `BirtReportExecutionIntegrationTest` and `BirtMigrationPipelineIntegrationTest` still pass, so `Active_Loans_Details` and the migrated reports are unaffected.

### ⚠️ Known CI coverage gap

**The MySQL/MariaDB path is not exercised in CI.** Covering it needs an `org.testcontainers:mariadb` test dependency, which I have deliberately left out of this PR. Current coverage is a unit test asserting `START TRANSACTION READ ONLY` is issued for a `jdbc:mariadb` URL, plus manual verification against a real MariaDB 11 instance with the MariaDB Connector/J 3.5.7 driver:

| Statement | PostgreSQL | MariaDB |
|---|---|---|
| `SELECT` | works | works |
| `INSERT` / `UPDATE` / `DELETE` | refused | refused |
| DDL | refused | **allowed** |
| `SET TRANSACTION READ WRITE` | refused | refused |
| `COMMIT; START TRANSACTION READ WRITE; INSERT` | **writes** | **writes** |
| pool connection writable afterwards | yes | yes |

Happy to add the dependency in a follow-up if maintainers want this in CI.

## Checklist

- [x] Written in the plugin's existing style, formatted with `spotless:apply`
- [x] `./mvnw clean verify` passes locally
- [x] Integration tests added for the security-relevant behaviour
- [x] No new configuration flags, services, DAOs, or dependencies
- [ ] Jira ticket — not filed; happy to do so if required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added per-report execution permission checks.
  * Prevented client-provided identity parameters from overriding server-managed values.
  * Reports now use read-only database access with protected credentials.
  * Blocked unsafe report paths and concealed filesystem details in missing-report errors.

* **Reliability**
  * Added validation for shipped report designs and database read-only behavior.
  * Improved coverage for report authorization, path security, and tenant database configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->