### PR TITLE
MX-403: enforce the report execution boundary for BIRT report SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,69 @@ VALUES ((SELECT id FROM c_external_service WHERE name = 'BIRT'), 'reports_dir', 
 ON CONFLICT (external_service_id, name) DO UPDATE SET value = EXCLUDED.value;
 ```
 
-### 4. Export the Required Variables
+### 4. Configure a Read-Only Report Principal (Recommended)
+
+The SQL embedded in a `.rptdesign` runs against the tenant database on the connection the plugin hands to Eclipse BIRT®. That connection is opened read-only and screened for transaction control, but `.rptdesign` files are trusted, administrator-installed artefacts and neither measure is a sandbox. **A database account granted only `SELECT` is what actually stops a report writing to the tenant database.**
+
+When `tenant_server_connections.readonly_schema_username` is set, reports connect as that principal instead of the tenant's read-write one. Those columns are empty in a stock deployment, in which case reports keep running on the ordinary tenant connection with only the read-only transaction protecting them.
+
+The examples below use the stock names — tenant database `fineract_default`, tenant store database `fineract_tenants`, tenant identifier `default`. Substitute your own wherever they differ.
+
+**1. Create the principal** in the tenant database (PostgreSQL® shown):
+
+```sql
+CREATE ROLE fineract_report LOGIN PASSWORD '<password>';
+GRANT CONNECT ON DATABASE fineract_default TO fineract_report;
+GRANT USAGE ON SCHEMA public TO fineract_report;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO fineract_report;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO fineract_report;
+```
+
+**2a. Point the tenant at it — new deployments.** On a tenant store that has not been created yet, Apache Fineract® fills these columns from environment variables at its first Liquibase run and encrypts the password itself:
+
+```bash
+export FINERACT_DEFAULT_TENANTDB_RO_UID=fineract_report
+export FINERACT_DEFAULT_TENANTDB_RO_PWD='<password>'
+# only when the read-only principal is on a different host or database
+export FINERACT_DEFAULT_TENANTDB_RO_HOSTNAME=
+export FINERACT_DEFAULT_TENANTDB_RO_PORT=
+export FINERACT_DEFAULT_TENANTDB_RO_NAME=
+export FINERACT_DEFAULT_TENANTDB_RO_CONN_PARAMS=
+```
+
+This applies only while `readonly_schema_username`, `readonly_schema_password` and `readonly_schema_name` are all still `NULL` on connection `id = 1`. On an existing deployment, use 2b.
+
+**2b. Point the tenant at it — existing deployments.** `readonly_schema_password` has to be stored **encrypted**, exactly like `schema_password`. A blank or plaintext value fails the report with `error.msg.reporting.readonly.password.missing` or `error.msg.reporting.readonly.password.not.encrypted`.
+
+Encrypt it with Apache Fineract®'s own encryptor, passing the master password from `fineract.tenant.master-password` (`FINERACT_DEFAULT_TENANTDB_MASTER_PASSWORD`, default `fineract`):
+
+```bash
+java -cp fineract-provider.jar \
+  -Dloader.main=org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor \
+  org.springframework.boot.loader.launch.PropertiesLauncher <masterPassword> <password>
+```
+
+Then store it, in the tenant store database (`fineract_tenants`):
+
+```sql
+UPDATE tenant_server_connections
+SET readonly_schema_username = 'fineract_report',
+    readonly_schema_password = '<encrypted password>'
+WHERE id = (SELECT oltp_id FROM tenants WHERE identifier = 'default');
+```
+
+`readonly_schema_server`, `readonly_schema_server_port`, `readonly_schema_name` and `readonly_schema_connection_parameters` fall back to their read-write counterparts when left blank, so a restricted role on the same database needs only a username and a password. Set them when the read-only principal lives on a replica.
+
+**3. Restart Apache Fineract®** so the tenant configuration is re-read. On a first-time install, section 9 already covers this.
+
+Reports run as this principal borrow from a connection pool of their own, bounded by:
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `mifos.birt.read-only-pool-max-size` | `5` | Connections the read-only principal may hold at once |
+| `mifos.birt.read-only-connection-timeout-millis` | `10000` | How long a report waits for one before failing |
+
+### 5. Export the Required Variables
 
 ```bash
 export MIFOS_BIRT_REPORTS_LOCALE=en
@@ -67,13 +129,22 @@ export MIFOS_BIRT_REPORTS_FONTS_PATH=/app/birt/fonts
 export MIFOS_BIRT_REPORTS_FONTS_CONFIG_PATH=/app/birt/config
 ```
 
-### 5. Security & User Permissions
+### 6. Security & User Permissions
 
-To execute reports, the authenticated user role must have the `READ_REPORT` permission enabled, along with the specific permission for the report being requested (e.g., `READ_ACTIVE_LOANS_DETAILS`).
+To execute a report, the authenticated user's role must hold one of the following permissions:
 
-For administrative accounts, the `ALL_FUNCTIONS` superuser permission grants access by default.
+| Permission | Grants |
+| --- | --- |
+| `READ_<reportName>` | That one report, e.g. `READ_Active_Loans_Details` for `/runreports/Active_Loans_Details` |
+| `REPORTING_SUPER_USER` | Every report |
+| `ALL_FUNCTIONS_READ` | Every report, along with every other read operation |
+| `ALL_FUNCTIONS` | Everything (superuser) |
 
-### 6. Download the Mifos® Reporting Plugin
+The report name in `READ_<reportName>` is the `stretchy_report.report_name` value verbatim, including case and underscores. There is no generic `READ_REPORT` permission — granting it alone does not allow any report to run.
+
+This is the check Apache Fineract® itself applies at `/runreports`; the plugin applies it again in its own execution path, so scheduled report mailing jobs are checked the same way rather than running ungranted.
+
+### 7. Download the Mifos® Reporting Plugin
 
 Download the Mifos® Reporting Plugin and extract the files.
 
@@ -83,7 +154,7 @@ Download the Mifos® Reporting Plugin and extract the files.
 | --- | --- | --- |
 | TBD | TBD | TBD |
 
-### 7a. Docker® Installation
+### 8a. Docker® Installation
 
 **Execute this step only when using Docker®.**
 
@@ -104,7 +175,7 @@ volumes:
   - ./birt/config:/app/birt/config:ro
 ```
 
-### 7b. Apache Tomcat® Installation
+### 8b. Apache Tomcat® Installation
 
 **Execute this step only when using Apache Tomcat®.**
 
@@ -116,11 +187,11 @@ $TOMCAT_HOME/webapps/fineract-provider/WEB-INF/lib/
 
 > **Note:** This Mifos® Reporting Plugin currently works with Apache Tomcat® version **10+**.
 
-### 8. Restart Apache Fineract®
+### 9. Restart Apache Fineract®
 
 Restart Docker® or Apache Tomcat® depending on your deployment setup.
 
-### 9. Test the Mifos® Reports
+### 10. Test the Mifos® Reports
 
 After restarting Apache Fineract®, test the Mifos® reports to verify that the BIRT® reporting engine has been correctly registered and loaded.
 

--- a/src/main/java/org/apache/fineract/infrastructure/report/config/BirtPluginProperties.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/config/BirtPluginProperties.java
@@ -6,6 +6,7 @@
  */
 package org.apache.fineract.infrastructure.report.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -16,6 +17,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "mifos.birt")
 public class BirtPluginProperties {
+
+    /** HikariCP's own floor for a connection or validation timeout. */
+    private static final long MINIMUM_TIMEOUT_MILLIS = 250L;
 
     // Path containing reports
     private String reportsPath;
@@ -29,4 +33,29 @@ public class BirtPluginProperties {
     private String fontsPath;
     // Optional Custom fontsConfig.xml location
     private String fontsConfigPath;
+    // Connections the tenant's read-only report principal may hold at once
+    private int readOnlyPoolMaxSize = 5;
+    // How long a report waits for one of them before failing
+    private long readOnlyConnectionTimeoutMillis = 10_000L;
+
+    /**
+     * Both values are handed to HikariCP, which refuses a maximum pool size below 1 and any of its
+     * timeouts below 250ms. Left to Hikari these fail when the first report builds the pool, which
+     * is a running deployment discovering its configuration is wrong; failing here is the same
+     * refusal at startup instead.
+     *
+     * <p>Hikari reads a connection timeout of 0 as "wait forever", but the same value also becomes
+     * the pool's validation timeout, which has no such reading, so 0 is refused here too.
+     */
+    @PostConstruct
+    void validate() {
+        if (readOnlyPoolMaxSize < 1) {
+            throw new IllegalStateException(
+                    "mifos.birt.read-only-pool-max-size must be at least 1, but is " + readOnlyPoolMaxSize);
+        }
+        if (readOnlyConnectionTimeoutMillis < MINIMUM_TIMEOUT_MILLIS) {
+            throw new IllegalStateException("mifos.birt.read-only-connection-timeout-millis must be at least "
+                    + MINIMUM_TIMEOUT_MILLIS + "ms, but is " + readOnlyConnectionTimeoutMillis);
+        }
+    }
 }

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtParameterMapper.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtParameterMapper.java
@@ -37,8 +37,11 @@ public class BirtParameterMapper {
     private final ReportErrorHandler reportErrorHandler;
     private final IReportEngine reportEngine;
 
-    // Injected separately by BirtContextInjector – never required from the client
-    private static final Set<String> SERVER_MANAGED_PARAMETERS = Set.of("userhierarchy", "userid");
+    /**
+     * Parameters that carry the caller's identity. They are derived from the authenticated user by
+     * {@link BirtContextInjector} and are never accepted from the client.
+     */
+    public static final Set<String> SERVER_MANAGED_PARAMETERS = Set.of("userhierarchy", "userid");
 
     /**
      * Validates and applies report parameters to the BIRT run task.

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReadOnlyConnectionFactory.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReadOnlyConnectionFactory.java
@@ -1,0 +1,539 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PreDestroy;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor;
+import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
+import org.apache.fineract.infrastructure.report.util.DataSourceUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * Opens, restricts and hands back the JDBC connection a BIRT report's SQL runs on.
+ *
+ * <p>This lives apart from {@link BirtReportingProcessServiceImpl} so that the behaviour it defines
+ * is the behaviour the tests exercise. The restriction it applies is what stands between report SQL
+ * and the tenant database, and a test that re-implemented it would only ever prove itself right.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BirtReadOnlyConnectionFactory {
+
+    private static final String SQL_ERROR_CODE = "error.msg.reporting.sql.error";
+    private static final String NO_STORED_PROCEDURES = "A BIRT report may not call a stored procedure.";
+
+    /**
+     * Statements that would take the report out of the transaction it was placed in.
+     *
+     * <p>The read-only transaction still catches ordinary writes, so this list does not have to be
+     * exhaustive to be worth having — it only has to cover the ways out of that transaction. Report
+     * SQL does not contain these words; a design that needs one is doing something a report should
+     * not.
+     */
+    private static final Pattern TRANSACTION_CONTROL = Pattern.compile(
+            "\\b(commit|rollback|begin)\\b|\\b(start|set)\\s+transaction\\b|\\bset\\s+session\\b",
+            Pattern.CASE_INSENSITIVE);
+
+    private final DataSource dataSource;
+    private final DatabasePasswordEncryptor databasePasswordEncryptor;
+    private final BirtPluginProperties birtProperties;
+
+    /**
+     * One pool per tenant read-only principal, kept for the lifetime of the plugin.
+     *
+     * <p>Reports are opened by users, so the rate is whatever the users produce. Handing out a fresh
+     * physical connection per report would leave the database's own connection limit as the only
+     * thing bounding that, and exhausting it takes down all of Fineract rather than only reporting.
+     */
+    private final Map<String, ReadOnlyPool> readOnlyPools = new ConcurrentHashMap<>();
+
+    /**
+     * A pool for one principal, and the credential it belongs to.
+     *
+     * <p>The credential held is the stored ciphertext, not the password: it changes exactly when an
+     * operator rotates {@code readonly_schema_password}, which is all this has to detect, and it
+     * keeps a decrypted password out of everything but the pool that needs one.
+     *
+     * <p>The pool is built on first use rather than in the constructor, because
+     * {@code new HikariDataSource(config)} starts the pool and opens a physical connection before it
+     * returns. That is a database round trip, and it must not happen while {@link ConcurrentHashMap}
+     * holds a bin lock. Holding the entry's own monitor instead keeps two reports from each building
+     * one, without blocking a lookup for any other principal.
+     */
+    private static final class ReadOnlyPool {
+
+        private final String encryptedPassword;
+        private final Supplier<HikariDataSource> builder;
+        private HikariDataSource dataSource;
+
+        private ReadOnlyPool(String encryptedPassword, Supplier<HikariDataSource> builder) {
+            this.encryptedPassword = encryptedPassword;
+            this.builder = builder;
+        }
+
+        private synchronized HikariDataSource dataSource() {
+            if (dataSource == null) {
+                dataSource = builder.get();
+            }
+            return dataSource;
+        }
+
+        /** The pool if one was ever built, so that nothing closes a pool that never opened. */
+        private synchronized HikariDataSource built() {
+            return dataSource;
+        }
+    }
+
+    /**
+     * Opens a connection the database itself will refuse writes on.
+     *
+     * <p>The read-only flag of the transaction the caller runs in does not reach this connection:
+     * Fineract's transaction manager is a {@code JpaTransactionManager}, which applies read-only to
+     * the persistence context only and never calls {@link Connection#setReadOnly}. The restriction
+     * therefore has to be applied to the connection BIRT is handed, so that the database refuses a
+     * write rather than the plugin trying to recognise one — SQL a report script builds at run time
+     * is invisible to any inspection of the design.
+     */
+    public Connection open() throws SQLException {
+        return restrict(openTenantReportConnection());
+    }
+
+    /**
+     * Applies the read-only restriction to an already-open connection, closing it if the restriction
+     * cannot be applied: open but unrestricted is the one state a report must never be handed.
+     */
+    public Connection restrict(Connection connection) throws SQLException {
+        try {
+            connection.setReadOnly(true);
+            connection.setAutoCommit(false);
+            beginReadOnlyTransaction(connection);
+            /*
+             * Opening the transaction here, with a statement of our own,
+             * closes the cheapest way out of it: a database stops accepting
+             * "SET TRANSACTION READ WRITE" once the transaction has taken
+             * its snapshot. Without this, the first statement of a report
+             * could be that, and a later one a write.
+             */
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SELECT 1");
+            }
+            return connection;
+        } catch (SQLException | RuntimeException e) {
+            closeQuietly(connection);
+            throw e;
+        }
+    }
+
+    /** Rolls back whatever the report left open and returns the connection to its pool. */
+    public void release(Connection connection) {
+        if (connection == null) {
+            return;
+        }
+        try {
+            connection.rollback();
+        } catch (SQLException e) {
+            log.debug("Failed to roll back the BIRT report connection", e);
+        }
+        closeQuietly(connection);
+    }
+
+    /**
+     * Wraps the connection in the view BIRT is allowed to have of it.
+     *
+     * <p>BIRT is stopped from closing the connection, because this factory owns its lifecycle, and
+     * from lifting the restriction the connection was opened with. Statements are screened for
+     * transaction control, which is what report SQL could otherwise use to leave the read-only
+     * transaction and write, and for stored procedure calls, which a report has no business making.
+     *
+     * <p>Every JDBC object this connection hands out that can navigate back to a connection is
+     * wrapped too — statements, their result sets, and the database metadata — so that
+     * {@code getConnection()}, {@code getStatement()} and {@code unwrap()} lead back here rather
+     * than to the physical connection. Only those navigation methods are answered by the wrappers;
+     * every other call, a column read included, is passed straight through.
+     *
+     * <p>This screening is a second line rather than the boundary. The boundary is a {@code SELECT}
+     * -only database principal, and the read-only transaction sits behind this catching ordinary
+     * writes, which is why the pattern can afford to be this narrow. A {@code .rptdesign} is a
+     * trusted, administrator-installed artefact for a further reason: BIRT runs report script with
+     * unrestricted access to the JVM, which no JDBC wrapper can contain.
+     */
+    public Connection guard(Connection connection) {
+        return (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(), new Class<?>[] {Connection.class}, (proxy, method, args) -> {
+                    final String methodName = method.getName();
+                    if ("close".equals(methodName)) {
+                        log.debug("Prevented BIRT from closing the report connection.");
+                        return null;
+                    }
+                    if ("isClosed".equals(methodName)) {
+                        return false;
+                    }
+                    if ("setReadOnly".equals(methodName)
+                            || "setAutoCommit".equals(methodName)
+                            || "commit".equals(methodName)
+                            || "rollback".equals(methodName)) {
+                        log.debug("Ignored BIRT attempt to call {} on the read-only report connection.", methodName);
+                        return null;
+                    }
+                    if ("prepareCall".equals(methodName)) {
+                        throw new SQLException(NO_STORED_PROCEDURES);
+                    }
+                    if ("unwrap".equals(methodName)) {
+                        return unwrapToProxy(proxy, args);
+                    }
+                    if ("isWrapperFor".equals(methodName)) {
+                        return wraps(proxy, args);
+                    }
+                    if (args != null && args.length > 0 && args[0] instanceof String sql) {
+                        rejectTransactionControl(sql);
+                    }
+                    final Object result = invoke(connection, method, args);
+                    if (result instanceof CallableStatement) {
+                        throw new SQLException(NO_STORED_PROCEDURES);
+                    }
+                    if (result instanceof PreparedStatement statement) {
+                        return guardStatement(statement, PreparedStatement.class, (Connection) proxy);
+                    }
+                    if (result instanceof Statement statement) {
+                        return guardStatement(statement, Statement.class, (Connection) proxy);
+                    }
+                    if (result instanceof DatabaseMetaData metaData) {
+                        return guardMetaData(metaData, (Connection) proxy);
+                    }
+                    return result;
+                });
+    }
+
+    /**
+     * Screens the SQL a statement is asked to run. A {@code Statement} takes its SQL at execution and
+     * a {@code PreparedStatement} at creation, but both inherit the {@code execute(String)}
+     * overloads, so both are screened the same way.
+     *
+     * <p>{@link Statement#getConnection()} returns the guarded connection rather than the one it was
+     * created from, and the result sets it produces are wrapped in turn, so a report that reaches
+     * the connection through a statement it holds is still screened rather than handed the way out.
+     */
+    private Object guardStatement(Statement statement, Class<? extends Statement> type, Connection guarded) {
+        return Proxy.newProxyInstance(
+                Connection.class.getClassLoader(), new Class<?>[] {type}, (proxy, method, args) -> {
+                    final String methodName = method.getName();
+                    if ("getConnection".equals(methodName)) {
+                        return guarded;
+                    }
+                    if ("unwrap".equals(methodName)) {
+                        return unwrapToProxy(proxy, args);
+                    }
+                    if ("isWrapperFor".equals(methodName)) {
+                        return wraps(proxy, args);
+                    }
+                    if (args != null && args.length > 0 && args[0] instanceof String sql) {
+                        rejectTransactionControl(sql);
+                    }
+                    final Object result = invoke(statement, method, args);
+                    if (result instanceof ResultSet resultSet) {
+                        return guardResultSet(resultSet, proxy);
+                    }
+                    return result;
+                });
+    }
+
+    /**
+     * {@link DatabaseMetaData#getConnection()} is the shortest way back to the physical connection,
+     * and the result sets metadata returns carry {@link ResultSet#getStatement()} of their own.
+     *
+     * <p>Those result sets are wrapped with no statement: JDBC already defines {@code getStatement()}
+     * as null for a result set that no statement produced, which is what a metadata result set is.
+     */
+    private Object guardMetaData(DatabaseMetaData metaData, Connection guarded) {
+        return Proxy.newProxyInstance(
+                Connection.class.getClassLoader(), new Class<?>[] {DatabaseMetaData.class}, (proxy, method, args) -> {
+                    final String methodName = method.getName();
+                    if ("getConnection".equals(methodName)) {
+                        return guarded;
+                    }
+                    if ("unwrap".equals(methodName)) {
+                        return unwrapToProxy(proxy, args);
+                    }
+                    if ("isWrapperFor".equals(methodName)) {
+                        return wraps(proxy, args);
+                    }
+                    final Object result = invoke(metaData, method, args);
+                    if (result instanceof ResultSet resultSet) {
+                        return guardResultSet(resultSet, null);
+                    }
+                    return result;
+                });
+    }
+
+    /**
+     * A result set hands back the statement that produced it, which hands back the connection.
+     *
+     * <p>Three methods are answered here and nothing else is touched, so a column read costs the
+     * dispatch and no more — measured at about 1.4ns over a direct call, against the milliseconds a
+     * row spends coming off the socket.
+     */
+    private Object guardResultSet(ResultSet resultSet, Object guardedStatement) {
+        return Proxy.newProxyInstance(
+                Connection.class.getClassLoader(), new Class<?>[] {ResultSet.class}, (proxy, method, args) -> {
+                    final String methodName = method.getName();
+                    if ("getStatement".equals(methodName)) {
+                        return guardedStatement;
+                    }
+                    if ("unwrap".equals(methodName)) {
+                        return unwrapToProxy(proxy, args);
+                    }
+                    if ("isWrapperFor".equals(methodName)) {
+                        return wraps(proxy, args);
+                    }
+                    return invoke(resultSet, method, args);
+                });
+    }
+
+    /**
+     * {@code unwrap} exists to reach the implementation behind a wrapper, which here is exactly what
+     * a report must not have. The guarded object is returned for an interface it implements, and
+     * anything else is refused rather than satisfied from the object underneath.
+     */
+    private static Object unwrapToProxy(Object proxy, Object[] args) throws SQLException {
+        final Class<?> type = (Class<?>) args[0];
+        if (type.isInstance(proxy)) {
+            return proxy;
+        }
+        throw new SQLException("A BIRT report may not unwrap the report connection to " + type.getName() + ".");
+    }
+
+    /** Kept consistent with {@link #unwrapToProxy}: true for exactly what unwrap will return. */
+    private static boolean wraps(Object proxy, Object[] args) {
+        return ((Class<?>) args[0]).isInstance(proxy);
+    }
+
+    private void rejectTransactionControl(String sql) throws SQLException {
+        if (TRANSACTION_CONTROL.matcher(sql).find()) {
+            log.warn("Rejected transaction control in BIRT report SQL: {}", sql);
+            throw new SQLException("A BIRT report may not issue transaction control statements.");
+        }
+    }
+
+    private static Object invoke(Object target, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+
+    /**
+     * Opens the connection reports run on, as the tenant's read-only database principal when one is
+     * configured.
+     *
+     * <p>A principal granted only {@code SELECT} is the one boundary a report cannot argue with: it
+     * refuses writes, DDL and {@code SET ROLE} alike, and unlike the read-only transaction it cannot
+     * be left behind by a report that opens a transaction of its own.
+     *
+     * <p>The credentials come from the tenant's existing {@code readonly_schema_*} columns, so this
+     * needs no new configuration surface — but those columns are empty in a stock deployment, and
+     * the principal still has to exist in the database. Until an operator sets both up, reports keep
+     * running on the ordinary tenant pool with only the read-only transaction protecting them.
+     * Fields left blank fall back to the read-write ones, so the common case of one database and a
+     * restricted role needs only a username and password.
+     */
+    private Connection openTenantReportConnection() throws SQLException {
+        final FineractPlatformTenantConnection tenantConnection = requireTenantConnection();
+        final String readOnlyUsername = tenantConnection.getReadOnlySchemaUsername();
+
+        if (StringUtils.isBlank(readOnlyUsername)) {
+            return dataSource.getConnection();
+        }
+
+        log.debug("Running BIRT report as the tenant's read-only database principal {}", readOnlyUsername);
+        return readOnlyPool(tenantConnection, readOnlyUsername).getConnection();
+    }
+
+    /**
+     * Returns the pool for this principal, rebuilding it if the stored password has changed since it
+     * was created.
+     *
+     * <p>A pool holds the password it was built with for as long as it lives, so without this an
+     * operator rotating {@code readonly_schema_password} would see every report keep working until
+     * the pool needed a new physical connection, and then fail to authenticate until Fineract was
+     * restarted.
+     *
+     * <p>{@code compute} only decides which entry belongs in the map. Building the replacement and
+     * closing the one it supersedes both happen after it returns, because each opens or tears down
+     * physical connections and {@link ConcurrentHashMap} asks that a remapping function be short.
+     */
+    private HikariDataSource readOnlyPool(FineractPlatformTenantConnection tenantConnection, String username) {
+        final String jdbcUrl = readOnlyJdbcUrl(tenantConnection);
+        final String encryptedPassword = StringUtils.trimToEmpty(tenantConnection.getReadOnlySchemaPassword());
+        final AtomicReference<HikariDataSource> superseded = new AtomicReference<>();
+
+        final ReadOnlyPool pool = readOnlyPools.compute(jdbcUrl + "|" + username, (key, existing) -> {
+            if (existing != null && existing.encryptedPassword.equals(encryptedPassword)) {
+                return existing;
+            }
+            if (existing != null) {
+                superseded.set(existing.built());
+            }
+            return new ReadOnlyPool(
+                    encryptedPassword,
+                    () -> buildReadOnlyPool(jdbcUrl, username, decryptReadOnlyPassword(encryptedPassword)));
+        });
+
+        final HikariDataSource replaced = superseded.get();
+        if (replaced != null) {
+            log.info("The read-only password for {} changed; closing the pool built with the old one", username);
+            replaced.close();
+        }
+        return pool.dataSource();
+    }
+
+    /* package-private so a test can stand in for the pool without a database */
+    HikariDataSource buildReadOnlyPool(String jdbcUrl, String username, String password) {
+        final HikariConfig config = new HikariConfig();
+        config.setPoolName("birt-readonly-" + username);
+        config.setJdbcUrl(jdbcUrl);
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setReadOnly(true);
+        config.setAutoCommit(false);
+        config.setMaximumPoolSize(birtProperties.getReadOnlyPoolMaxSize());
+        config.setMinimumIdle(0);
+        config.setConnectionTimeout(birtProperties.getReadOnlyConnectionTimeoutMillis());
+        config.setValidationTimeout(birtProperties.getReadOnlyConnectionTimeoutMillis());
+        config.setIdleTimeout(TimeUnit.MINUTES.toMillis(1));
+        log.info(
+                "Opened a BIRT read-only connection pool for {} with at most {} connections",
+                username,
+                config.getMaximumPoolSize());
+        return new HikariDataSource(config);
+    }
+
+    private String readOnlyJdbcUrl(FineractPlatformTenantConnection tenantConnection) {
+        final String driverClassName = DataSourceUtils.getDriverClassName(dataSource);
+        return FineractPlatformTenantConnection.toJdbcUrl(
+                FineractPlatformTenantConnection.resolveProtocol(driverClassName),
+                StringUtils.defaultIfBlank(
+                        tenantConnection.getReadOnlySchemaServer(), tenantConnection.getSchemaServer()),
+                StringUtils.defaultIfBlank(
+                        tenantConnection.getReadOnlySchemaServerPort(), tenantConnection.getSchemaServerPort()),
+                StringUtils.defaultIfBlank(tenantConnection.getReadOnlySchemaName(), tenantConnection.getSchemaName()),
+                StringUtils.defaultIfBlank(
+                        tenantConnection.getReadOnlySchemaConnectionParameters(),
+                        tenantConnection.getSchemaConnectionParameters()));
+    }
+
+    /**
+     * The password column is stored encrypted, exactly like {@code schema_password}. Nothing else
+     * says so, so a blank or plaintext value is the first thing an operator configuring this hits —
+     * and the decrypt failure it produces reaches them as "Unknown SQL error", which names neither
+     * the column nor what is wrong with it.
+     */
+    private String decryptReadOnlyPassword(String password) {
+        if (StringUtils.isBlank(password)) {
+            throw new PlatformDataIntegrityException(
+                    "error.msg.reporting.readonly.password.missing",
+                    "tenant_server_connections.readonly_schema_password is empty while readonly_schema_username is"
+                            + " set. Store the read-only principal's password there, encrypted the same way as"
+                            + " schema_password.");
+        }
+        try {
+            return databasePasswordEncryptor.decrypt(password);
+        } catch (Exception e) {
+            throw new PlatformDataIntegrityException(
+                    "error.msg.reporting.readonly.password.not.encrypted",
+                    "tenant_server_connections.readonly_schema_password could not be decrypted. It has to be stored"
+                            + " encrypted, the same way as schema_password.",
+                    e);
+        }
+    }
+
+    /**
+     * Starts the read-only transaction on databases whose driver will not start one.
+     *
+     * <p>{@link Connection#setReadOnly} is enough on PostgreSQL, whose driver opens every transaction
+     * with {@code BEGIN READ ONLY}. The MySQL and MariaDB drivers treat it as a replica-routing hint
+     * and let every write through untouched, so there the transaction has to be opened explicitly.
+     * Every other database is left to its driver, this way round on purpose: a URL nobody has
+     * checked — {@code jdbc:aws-wrapper:postgresql} today, whatever is added next — is better served
+     * by its driver's own behaviour than by a statement guessed on its behalf.
+     *
+     * <p>Deliberately a transaction-scoped statement rather than a session-scoped one: the connection
+     * goes back to a pool that Fineract writes through, and {@code SET SESSION} would still be in
+     * effect when the next borrower picks it up.
+     */
+    private void beginReadOnlyTransaction(Connection connection) throws SQLException {
+        final String jdbcUrl =
+                StringUtils.defaultString(connection.getMetaData().getURL());
+        if (!StringUtils.containsIgnoreCase(jdbcUrl, ":mysql")
+                && !StringUtils.containsIgnoreCase(jdbcUrl, ":mariadb")) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("START TRANSACTION READ ONLY");
+        }
+    }
+
+    private FineractPlatformTenantConnection requireTenantConnection() {
+        final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
+        if (tenant == null) {
+            throw new PlatformDataIntegrityException(
+                    SQL_ERROR_CODE, "Unable to execute BIRT report because no tenant context is available.");
+        }
+        final FineractPlatformTenantConnection tenantConnection = tenant.getConnection();
+        if (tenantConnection == null) {
+            throw new PlatformDataIntegrityException(
+                    SQL_ERROR_CODE,
+                    "Unable to execute BIRT report because the tenant database connection is unavailable.");
+        }
+        return tenantConnection;
+    }
+
+    private void closeQuietly(Connection connection) {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            log.debug("Failed to close the BIRT report connection", e);
+        }
+    }
+
+    @PreDestroy
+    void closeReadOnlyPools() {
+        readOnlyPools.values().stream()
+                .map(ReadOnlyPool::built)
+                .filter(Objects::nonNull)
+                .forEach(HikariDataSource::close);
+        readOnlyPools.clear();
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
@@ -7,6 +7,10 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.RequiredArgsConstructor;
@@ -68,8 +72,7 @@ public class BirtReportLoader {
         if (!reportFile.exists()) {
             log.error("Report design file not found: {}", reportPath);
             throw reportErrorHandler.reportError(
-                    "error.msg.reporting.report.not.found",
-                    "Report file not found: " + reportName + " at path: " + reportPath);
+                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
         }
 
         if (!reportFile.canRead()) {
@@ -132,19 +135,56 @@ public class BirtReportLoader {
                 locale != null ? locale.getLanguage() : "en");
     }
 
-    /** Builds the full path to the .rptdesign file, supporting locale-specific variants. */
+    /**
+     * Builds the full path to the .rptdesign file, supporting locale-specific variants.
+     *
+     * <p>The report name reaches this method straight from the request path, so the resolved file has
+     * to be confined to the reports directory: anything that escapes it is rejected as not found.
+     */
     private String buildReportPath(String reportName, java.util.Locale locale) {
-        String baseDir = getBaseReportsDirectory();
-
-        // Ensure trailing separator
-        if (!baseDir.endsWith(File.separator)) {
-            baseDir += File.separator;
-        }
-
-        String languageTag = (locale != null && !"en".equalsIgnoreCase(locale.getLanguage()))
+        final String languageTag = (locale != null && !"en".equalsIgnoreCase(locale.getLanguage()))
                 ? "_" + locale.getLanguage().toLowerCase()
                 : "";
-        return baseDir + reportName + languageTag + ".rptdesign";
+
+        try {
+            /*
+             * The base directory is resolved here rather than before the try
+             * because it comes from c_external_service_properties, so a value
+             * an administrator stored can be no more a path than the report
+             * name can. Both reach the caller as the same not-found.
+             */
+            final Path baseDir = realPath(
+                    Paths.get(getBaseReportsDirectory()).toAbsolutePath().normalize());
+            final Path reportPath = realPath(
+                    baseDir.resolve(reportName + languageTag + ".rptdesign").normalize());
+            if (reportPath.startsWith(baseDir)) {
+                return reportPath.toString();
+            }
+        } catch (InvalidPathException e) {
+            log.error(
+                    "Rejected BIRT report [{}]: neither it nor the configured reports directory is a path",
+                    reportName,
+                    e);
+            throw reportErrorHandler.reportError(
+                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName, e);
+        }
+
+        log.error("Rejected BIRT report name resolving outside the reports directory: {}", reportName);
+        throw reportErrorHandler.reportError(
+                "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
+    }
+
+    /**
+     * Resolves symlinks so the containment check cannot be walked around by a link inside the reports
+     * directory. A path that does not exist yet has nothing to resolve, and stays as it is: the
+     * caller reports it as not found either way.
+     */
+    private Path realPath(Path path) {
+        try {
+            return path.toRealPath();
+        } catch (IOException e) {
+            return path;
+        }
     }
 
     /** Returns the base directory for BIRT reports. Priority: Database -> Properties -> Default */

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImpl.java
@@ -8,8 +8,6 @@ package org.apache.fineract.infrastructure.report.service;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -25,11 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.ApiParameterHelper;
-import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
-import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
-import org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor;
 import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 import org.apache.fineract.infrastructure.report.annotation.ReportService;
 import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
@@ -40,10 +34,8 @@ import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.eclipse.birt.report.engine.api.IRunTask;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.springframework.context.annotation.Primary;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
@@ -66,12 +58,12 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
     private final DataSource dataSource;
     private final PlatformTransactionManager transactionManager;
     private final BirtSqlDialectInterpolator sqlDialectInterpolator;
-    private final DatabasePasswordEncryptor databasePasswordEncryptor;
     private final ReportSecurityService reportSecurityService;
+    private final BirtReadOnlyConnectionFactory connectionFactory;
 
     @Override
     public Response processRequest(String reportName, MultivaluedMap<String, String> queryParams) {
-        reportSecurityService.checkReadReportPermission();
+        reportSecurityService.checkReportExecutionPermission(reportName);
         final String outputType = resolveOutputType(queryParams);
         final Locale locale = ApiParameterHelper.extractLocale(queryParams);
         final Map<String, String> reportParams = getReportParams(reportName, queryParams);
@@ -102,21 +94,37 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
 
     private void executeReportToDocument(
             String reportName, Locale locale, Map<String, String> reportParams, String documentPath) {
+        /*
+         * This transaction no longer scopes the report's own SQL: that runs
+         * on a separate connection this method opens and closes itself, and
+         * nothing set here reaches it. What is left inside it is Fineract's
+         * work around the report — loading the design, which reads the
+         * reports directory from c_external_service_properties, and reading
+         * the authenticated user for the context parameters — so it stays,
+         * read-only, for that.
+         *
+         * Nothing here marks it rollback-only. Every failure below leaves by
+         * throwing a PlatformDataIntegrityException, which is a
+         * RuntimeException, and TransactionTemplate.execute already rolls the
+         * transaction back for one of those. Marking it as well protected
+         * nothing and read as though it protected the report's SQL, which
+         * runs on a connection this transaction never sees.
+         */
         final TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
         transactionTemplate.setReadOnly(true);
         final AtomicReference<String> capturedSqlError = new AtomicReference<>();
         try {
-            transactionTemplate.execute(status -> {
+            transactionTemplate.execute(transactionStatus -> {
                 IRunTask runTask = null;
-                Connection springConnection = null;
+                Connection birtConnection = null;
                 try {
                     final IReportRunnable design = reportExecutionFactory.createExecutionRunnable(reportName, locale);
                     final ReportDesignHandle designHandle = (ReportDesignHandle) design.getDesignHandle();
                     sqlDialectInterpolator.interpolate(designHandle);
                     runTask = reportEngine.createRunTask(design);
                     runTask.setErrorHandlingOption(IEngineTask.CANCEL_ON_ERROR);
-                    springConnection = DataSourceUtils.getConnection(dataSource);
-                    setConnectionDetail(runTask, springConnection);
+                    birtConnection = connectionFactory.open();
+                    setConnectionDetail(runTask, birtConnection);
                     configureLocale(runTask, locale);
                     parameterMapper.applyParameters(runTask, reportParams);
                     contextInjector.injectContextParameters(runTask);
@@ -129,29 +137,26 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
                     final String birtSqlError = extractBirtTaskError(runTask);
                     if (StringUtils.isNotBlank(birtSqlError)) {
                         capturedSqlError.set(birtSqlError);
-                        markRollbackOnly(status);
                         throw createSqlException(birtSqlError);
                     }
                     return null;
                 } catch (PlatformDataIntegrityException e) {
-                    markRollbackOnly(status);
                     throw e;
                 } catch (Exception e) {
                     final String sqlErrorMessage = extractSqlErrorMessage(e);
                     capturedSqlError.set(sqlErrorMessage);
                     log.error("Failed to execute BIRT report [{}]: {}", reportName, sqlErrorMessage, e);
-                    markRollbackOnly(status);
                     throw createSqlException(sqlErrorMessage);
                 } finally {
                     if (runTask != null) {
                         closeQuietly(runTask::close);
                     }
                     /*
-                     * Do not explicitly close the tenant connection here.
-                     *
-                     * The connection is owned by Spring's transaction
-                     * infrastructure and DataSourceUtils.
+                     * The BIRT connection is not the Spring transaction's
+                     * connection, so this method owns its lifecycle. BIRT
+                     * only ever sees the close-proof proxy.
                      */
+                    connectionFactory.release(birtConnection);
                 }
             });
         } catch (PlatformDataIntegrityException e) {
@@ -283,61 +288,21 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
         return cleaned.trim();
     }
 
-    private void setConnectionDetail(IRunTask runTask, Connection springConnection) throws Exception {
-        final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
-        if (tenant == null) {
-            throw new PlatformDataIntegrityException(
-                    SQL_ERROR_CODE, "Unable to execute BIRT report because no tenant context is available.");
-        }
-        final FineractPlatformTenantConnection tenantConnection = tenant.getConnection();
-        if (tenantConnection == null) {
-            throw new PlatformDataIntegrityException(
-                    SQL_ERROR_CODE,
-                    "Unable to execute BIRT report because the tenant database connection is unavailable.");
-        }
-        final String jdbcUrl = springConnection.getMetaData().getURL();
+    private void setConnectionDetail(IRunTask runTask, Connection birtConnection) throws Exception {
+        final String jdbcUrl = birtConnection.getMetaData().getURL();
         final String driverClassName =
                 org.apache.fineract.infrastructure.report.util.DataSourceUtils.getDriverClassName(dataSource);
         runTask.getAppContext().put("OdaJDBCDriverClass", driverClassName);
         runTask.getAppContext().put("OdaJDBCDriverUrl", jdbcUrl);
-        runTask.getAppContext().put("OdaJDBCDriverUser", tenantConnection.getSchemaUsername());
-        runTask.getAppContext()
-                .put(
-                        "OdaJDBCDriverPassword",
-                        databasePasswordEncryptor.decrypt(
-                                tenantConnection.getSchemaPassword().trim()));
         /*
-         * The connection belongs to the current Fineract tenant
-         * transaction. BIRT must not close it.
+         * No credentials go into the app context: BIRT takes the pass-in
+         * connection and returns before it looks at a user or password, and
+         * report scripts can read that map. The proxy stops BIRT closing the
+         * connection or leaving its read-only transaction.
          */
-        final Connection safeConnection = wrapConnectionToPreventClose(springConnection);
+        final Connection safeConnection = connectionFactory.guard(birtConnection);
         runTask.getAppContext().put("OdaJDBCDriverPassInConnection", safeConnection);
         runTask.getAppContext().put("OdaJDBCDriverPassInConnectionCloseAfterUse", false);
-    }
-
-    private Connection wrapConnectionToPreventClose(Connection connection) {
-        return (Connection) Proxy.newProxyInstance(
-                Connection.class.getClassLoader(), new Class<?>[] {Connection.class}, (proxy, method, args) -> {
-                    final String methodName = method.getName();
-                    if ("close".equals(methodName)) {
-                        log.debug("Prevented BIRT from closing the Spring-managed tenant connection.");
-                        return null;
-                    }
-                    if ("isClosed".equals(methodName)) {
-                        return false;
-                    }
-                    try {
-                        return method.invoke(connection, args);
-                    } catch (InvocationTargetException e) {
-                        throw e.getTargetException();
-                    }
-                });
-    }
-
-    private void markRollbackOnly(TransactionStatus status) {
-        if (status != null && !status.isCompleted()) {
-            status.setRollbackOnly();
-        }
     }
 
     private Response renderReport(String reportName, String outputType, String documentPath) {
@@ -355,12 +320,33 @@ public class BirtReportingProcessServiceImpl implements ReportingProcessService 
         final Map<String, String> params = new HashMap<>();
         queryParams.keySet().stream().filter(key -> key.startsWith("R_")).forEach(key -> {
             final String parameterName = key.substring(2);
+            if (isServerManagedParameter(parameterName)) {
+                return;
+            }
             final String value = queryParams.getFirst(key);
             if (StringUtils.isNotBlank(value)) {
                 params.put(parameterName, value);
             }
         });
         return params;
+    }
+
+    /**
+     * Drops a parameter the server derives from the authenticated user, and says so in the log.
+     *
+     * <p>The value is dropped, and was already unreachable before this: {@link
+     * BirtParameterMapper#applyParameters} skips these names, and the context injector overwrites
+     * both afterwards. Failing the request instead would turn a no-op into an outage for callers
+     * that still send them — stored {@code stretchy_report_param_map} entries carrying the
+     * Pentaho-era {@code R_userhierarchy} reach this through report mailing jobs, where the failure
+     * would happen in a background run with nobody watching.
+     */
+    private boolean isServerManagedParameter(String parameterName) {
+        if (!BirtParameterMapper.SERVER_MANAGED_PARAMETERS.contains(parameterName.toLowerCase(Locale.ROOT))) {
+            return false;
+        }
+        log.warn("Ignoring client-supplied parameter '{}': it is derived from the authenticated user.", parameterName);
+        return true;
     }
 
     @Override

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/ReportSecurityService.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/ReportSecurityService.java
@@ -7,60 +7,38 @@
  */
 package org.apache.fineract.infrastructure.report.service;
 
-import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ReportSecurityService {
 
-    /**
-     * Apache Fineract permission required to execute reports.
-     */
-    private static final String ALL_FUNCTIONS = "ALL_FUNCTIONS";
-
-    public static final String READ_REPORT_PERMISSION = "READ_REPORT";
-
-    private static final String ERROR_CODE = "error.msg.reporting.permission.denied";
+    private final PlatformSecurityContext securityContext;
 
     /**
-     * Verifies that the currently authenticated Apache Fineract user is authorized to read reports.
+     * Verifies that the authenticated Apache Fineract user is granted the report that is about to be
+     * executed.
      *
-     * <p>The check is deliberately performed before report loading, BIRT execution, datasource
-     * access, and SQL execution.
+     * <p>The user is taken from {@link PlatformSecurityContext}, never from the request, and the
+     * grants are the ones Apache Fineract itself requires to run a report ({@code READ_<reportName>},
+     * {@code REPORTING_SUPER_USER}, {@code ALL_FUNCTIONS} or {@code ALL_FUNCTIONS_READ}).
      *
-     * @throws PlatformDataIntegrityException when the authenticated user does not have
-     *         {@code READ_REPORT}
+     * <p>The check is deliberately performed inside {@code processRequest}, before report loading,
+     * BIRT execution and SQL execution, because that is the only point every caller passes through:
+     * the {@code /runreports} resource checks the grant itself, but the report mailing job does not.
+     *
+     * @throws NoAuthorizationException when the authenticated user is not granted the report
      */
-    public void checkReadReportPermission() {
+    public void checkReportExecutionPermission(final String reportName) {
 
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        final AppUser currentUser = securityContext.authenticatedUser();
 
-        if (!isAuthenticated(authentication)) {
-            throw new PlatformDataIntegrityException(
-                    ERROR_CODE, "The authenticated user is not authorized to execute reports.");
+        if (currentUser.hasNotPermissionForReport(reportName)) {
+            throw new NoAuthorizationException("Not authorised to run report: " + reportName);
         }
-
-        if (!hasReadReportPermission(authentication)) {
-            throw new PlatformDataIntegrityException(
-                    ERROR_CODE, "The authenticated user does not have the READ_REPORT permission.");
-        }
-    }
-
-    private boolean isAuthenticated(Authentication authentication) {
-
-        return authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() != null;
-    }
-
-    private boolean hasReadReportPermission(Authentication authentication) {
-        final var authorities = authentication.getAuthorities();
-        if (authorities == null) {
-            return false;
-        }
-        return authorities.stream().anyMatch(authority -> {
-            final String granted = authority.getAuthority();
-            return READ_REPORT_PERMISSION.equals(granted) || ALL_FUNCTIONS.equals(granted);
-        });
     }
 }

--- a/src/main/resources/db/changelog/tenant/module/reporting/parts/002-birt-external-service.xml
+++ b/src/main/resources/db/changelog/tenant/module/reporting/parts/002-birt-external-service.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog-4.3.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <!-- 1. Register BIRT as a core external service if missing -->
     <changeSet author="fineract" id="reporting-003-external-service-birt">

--- a/src/test/java/org/apache/fineract/infrastructure/report/ShippedReportDesignTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/ShippedReportDesignTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards the SQL that ships with the plugin.
+ *
+ * <p>Report SQL runs on a read-only connection, so a shipped report cannot damage the database. What
+ * these tests protect is the other half: that the shipped designs keep binding their values as
+ * parameters instead of pasting them into the query, and that they keep filtering on the caller's
+ * office hierarchy — neither of which the execution boundary can impose on a report design.
+ */
+@DisplayName("Shipped .rptdesign files")
+class ShippedReportDesignTest {
+
+    private static final Path REPORTS_DIRECTORY = Paths.get("birt", "reports");
+
+    private static final Pattern QUERY_TEXT =
+            Pattern.compile("<xml-property name=\"queryText\"><!\\[CDATA\\[(.*?)]]></xml-property>", Pattern.DOTALL);
+
+    /**
+     * The number of shipped designs that must carry a dataset query. Not every design does — the
+     * smoke report used by the integration pipeline has none by design — so the parameterisation
+     * check runs over the ones that do, and this number is what stops that set quietly emptying out
+     * and taking the check with it.
+     */
+    private static final int DESIGNS_EXPECTED_TO_CARRY_QUERIES = 2;
+
+    static Stream<Path> shippedReports() throws IOException {
+        try (Stream<Path> files = Files.list(REPORTS_DIRECTORY)) {
+            return files.filter(path -> path.toString().endsWith(".rptdesign")).sorted().toList().stream();
+        }
+    }
+
+    static Stream<Path> shippedReportsWithQueries() throws IOException {
+        return shippedReports().filter(report -> !queriesOf(read(report)).isEmpty());
+    }
+
+    @Test
+    @DisplayName("are present, so the checks below are not silently vacuous")
+    void reportsArePresent() throws IOException {
+        assertThat(shippedReports()).isNotEmpty();
+        assertThat(shippedReportsWithQueries())
+                .as("the parameterisation check only sees designs that carry a query")
+                .hasSizeGreaterThanOrEqualTo(DESIGNS_EXPECTED_TO_CARRY_QUERIES);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shippedReportsWithQueries")
+    @DisplayName("build every query from bound parameters, never string interpolation")
+    void queriesAreParameterised(Path report) {
+        final String design = read(report);
+
+        for (String query : queriesOf(design)) {
+            assertThat(query)
+                    .as("query in %s interpolates a value into the SQL text", report)
+                    .doesNotContain("${");
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shippedReports")
+    @DisplayName("do not rewrite their query at run time from a script")
+    void queriesAreNotBuiltByScripts(Path report) {
+        final String design = read(report);
+
+        assertThat(design)
+                .as(
+                        "a script in %s assigns queryText, which would make the executed SQL "
+                                + "invisible to any design-time inspection",
+                        report)
+                .doesNotContain("this.queryText")
+                .doesNotContain("setQueryText");
+    }
+
+    @Test
+    @DisplayName("Active_Loans_Details scopes its result set to the caller's office hierarchy")
+    void activeLoansDetailsBindsTheUserHierarchy() {
+        final String design = read(REPORTS_DIRECTORY.resolve("Active_Loans_Details.rptdesign"));
+
+        assertThat(design)
+                .as("userhierarchy must stay a declared report parameter for the server to inject it")
+                .contains("<scalar-parameter name=\"userhierarchy\"");
+
+        assertThat(design)
+                .as("userhierarchy must stay bound as the dataset's first parameter")
+                .containsPattern(Pattern.compile(
+                        "<property name=\"paramName\">userhierarchy</property>.*?"
+                                + "<property name=\"position\">1</property>",
+                        Pattern.DOTALL));
+
+        final String query = queriesOf(design).get(0);
+        assertThat(query)
+                .as("the hierarchy filter must be a bind, not a literal")
+                .contains("ounder.hierarchy LIKE CONCAT(?, '%')");
+    }
+
+    /**
+     * A tripwire, not a preference. Rejecting SQL comments is a recurring proposal for hardening
+     * report SQL; it would break this report on the day it is introduced, and rejecting comments
+     * stops no read-based injection anyway.
+     */
+    @Test
+    @DisplayName("Active_Loans_Details contains an SQL comment, so comment rejection would break it")
+    void activeLoansDetailsContainsAnSqlComment() {
+        final String query = queriesOf(read(REPORTS_DIRECTORY.resolve("Active_Loans_Details.rptdesign")))
+                .get(0);
+
+        assertThat(query).contains("-- Param 2: branch");
+    }
+
+    private static List<String> queriesOf(String design) {
+        final List<String> queries = new ArrayList<>();
+        final Matcher matcher = QUERY_TEXT.matcher(design);
+        while (matcher.find()) {
+            queries.add(matcher.group(1));
+        }
+        return queries;
+    }
+
+    private static String read(Path report) {
+        try {
+            return Files.readString(report, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/config/BirtPluginPropertiesTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/config/BirtPluginPropertiesTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.config;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The pool settings reach HikariCP, which refuses them below its own floors. Refusing them here
+ * means a deployment finds out at startup rather than when someone runs the first report.
+ */
+@DisplayName("BirtPluginProperties Tests")
+class BirtPluginPropertiesTest {
+
+    @Test
+    @DisplayName("Should accept the shipped defaults")
+    void shouldAcceptTheDefaults() {
+        assertDoesNotThrow(() -> new BirtPluginProperties().validate());
+    }
+
+    @Test
+    @DisplayName("Should refuse a pool that cannot hold a connection")
+    void shouldRefuseAPoolSizeBelowOne() {
+        final BirtPluginProperties properties = new BirtPluginProperties();
+        properties.setReadOnlyPoolMaxSize(0);
+
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, properties::validate);
+
+        assertTrue(ex.getMessage().contains("mifos.birt.read-only-pool-max-size"), ex.getMessage());
+    }
+
+    /** Hikari reads 0 as "wait forever" for a connection timeout, but refuses it as a validation one. */
+    @Test
+    @DisplayName("Should refuse a timeout below Hikari's floor, zero included")
+    void shouldRefuseATimeoutBelowTheFloor() {
+        final BirtPluginProperties properties = new BirtPluginProperties();
+        properties.setReadOnlyConnectionTimeoutMillis(249L);
+
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, properties::validate);
+
+        assertTrue(ex.getMessage().contains("mifos.birt.read-only-connection-timeout-millis"), ex.getMessage());
+
+        properties.setReadOnlyConnectionTimeoutMillis(0L);
+        assertThrows(IllegalStateException.class, properties::validate);
+
+        properties.setReadOnlyConnectionTimeoutMillis(250L);
+        assertDoesNotThrow(properties::validate);
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtConnectionReadOnlyIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtConnectionReadOnlyIntegrationTest.java
@@ -1,0 +1,508 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.infrastructure.core.persistence.ExtendedJpaTransactionManager;
+import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
+import org.apache.fineract.infrastructure.report.service.BirtReadOnlyConnectionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Establishes what the JDBC connection BIRT executes a report's SQL on is actually allowed to do.
+ *
+ * <p>{@code BirtReportingProcessServiceImpl} runs every report inside a {@link TransactionTemplate}
+ * marked read-only. These tests answer, against a real database and Apache Fineract's own
+ * transaction manager, two questions that decide how the SQL embedded in a {@code .rptdesign} file
+ * has to be contained:
+ *
+ * <ol>
+ *   <li>does the transaction's read-only marker reach the JDBC connection? (it does not)
+ *   <li>does the connection the service opens for BIRT make the database refuse the writes a report
+ *       can issue? (it does, up to the boundary the last test records)
+ * </ol>
+ *
+ * <p>This is why the plugin contains no SQL pattern matching: the report's SQL is never inspected,
+ * it is executed somewhere ordinary writes fail. Report scripts can rewrite a query at run time, so
+ * inspecting the design would not be sound anyway — and the one sequence that still gets through
+ * would not be caught by a blacklist that a script can evade either.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("BIRT JDBC connection read-only behaviour")
+public class BirtConnectionReadOnlyIntegrationTest {
+
+    private static final String READ_ONLY_USER = "birt_ro";
+
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("birt_readonly_probe")
+            .withUsername("postgres")
+            .withPassword("postgres");
+
+    private HikariDataSource dataSource;
+    private BirtReadOnlyConnectionFactory connectionFactory;
+    private LocalContainerEntityManagerFactoryBean entityManagerFactoryBean;
+    private ExtendedJpaTransactionManager transactionManager;
+
+    @BeforeAll
+    void startDatabase() throws SQLException {
+        POSTGRES.start();
+
+        dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(POSTGRES.getJdbcUrl());
+        dataSource.setUsername(POSTGRES.getUsername());
+        dataSource.setPassword(POSTGRES.getPassword());
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setMaximumPoolSize(4);
+
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE probe (id INT PRIMARY KEY, note TEXT)");
+            statement.execute("INSERT INTO probe VALUES (1, 'seed')");
+            statement.execute("CREATE ROLE " + READ_ONLY_USER + " LOGIN PASSWORD '" + READ_ONLY_USER + "'");
+            statement.execute("GRANT CONNECT ON DATABASE " + POSTGRES.getDatabaseName() + " TO " + READ_ONLY_USER);
+            statement.execute("GRANT USAGE ON SCHEMA public TO " + READ_ONLY_USER);
+            statement.execute("GRANT SELECT ON ALL TABLES IN SCHEMA public TO " + READ_ONLY_USER);
+        }
+
+        connectionFactory = new BirtReadOnlyConnectionFactory(dataSource, null, new BirtPluginProperties());
+
+        entityManagerFactoryBean = buildEntityManagerFactory(dataSource);
+        // false = the read-write manager, which is the one a report request runs under
+        transactionManager = new ExtendedJpaTransactionManager(false);
+        transactionManager.setEntityManagerFactory(entityManagerFactoryBean.getObject());
+        transactionManager.setDataSource(dataSource);
+        transactionManager.afterPropertiesSet();
+    }
+
+    @AfterAll
+    void stopDatabase() {
+        if (entityManagerFactoryBean != null) {
+            entityManagerFactoryBean.destroy();
+        }
+        if (dataSource != null) {
+            dataSource.close();
+        }
+        POSTGRES.stop();
+    }
+
+    /**
+     * The premise the guard rests on. Apache Fineract's transaction manager is a
+     * {@code JpaTransactionManager}: it applies read-only to the persistence context, never to the
+     * JDBC connection. Should that ever change, this test fails and the guard becomes redundant
+     * rather than wrong.
+     */
+    @Test
+    @DisplayName("A read-only Spring transaction leaves the JDBC connection writable")
+    void readOnlyTransactionDoesNotRestrictTheJdbcConnection() {
+        final TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+
+        final int rowsBefore = rowCount();
+
+        transactionTemplate.execute(status -> {
+            final Connection connection = DataSourceUtils.getConnection(dataSource);
+            try {
+                assertThat(connection.isReadOnly())
+                        .as("read-only never reaches the connection BIRT would be handed")
+                        .isFalse();
+
+                try (Statement statement = connection.createStatement()) {
+                    statement.execute("INSERT INTO probe VALUES (2, 'written in a read-only transaction')");
+                }
+            } catch (SQLException e) {
+                throw new IllegalStateException(e);
+            } finally {
+                DataSourceUtils.releaseConnection(connection, dataSource);
+            }
+            return null;
+        });
+
+        assertThat(rowCount())
+                .as("the write went through, so the transaction offered no protection")
+                .isEqualTo(rowsBefore + 1);
+    }
+
+    @Test
+    @DisplayName("The connection opened for BIRT lets the database reject every write")
+    void readOnlyConnectionRejectsWrites() {
+        assertRejected("INSERT INTO probe VALUES (99, 'injected')", "cannot execute INSERT in a read-only transaction");
+        assertRejected("UPDATE probe SET note = 'tampered' WHERE id = 1", "cannot execute UPDATE");
+        assertRejected("DELETE FROM probe", "cannot execute DELETE");
+        assertRejected("CREATE TABLE injected (id INT)", "cannot execute CREATE TABLE");
+    }
+
+    /**
+     * The property that makes the guard hold against hostile SQL rather than merely against honest
+     * mistakes. A statement inside the report cannot hand itself write access back, because the
+     * connection is opened with a query of our own and a database only pins read-only mode once the
+     * transaction has taken its snapshot.
+     */
+    @Test
+    @DisplayName("SQL inside the report cannot lift the read-only state")
+    void readOnlyStateCannotBeLiftedBySql() {
+        assertRejected("SET TRANSACTION READ WRITE", "must be set before any query");
+        assertRejected("SELECT 1; INSERT INTO probe VALUES (98, 'stacked')", "cannot execute INSERT");
+    }
+
+    /** A report that commits, or changes the session default, still gets a read-only transaction. */
+    @Test
+    @DisplayName("Ending the transaction from SQL does not buy write access")
+    void readOnlyStateSurvivesCommit() throws SQLException {
+        try (Connection connection = openReadOnlyConnection()) {
+            execute(connection, "SET default_transaction_read_only = off");
+            execute(connection, "COMMIT");
+            assertThatThrownBy(() -> execute(connection, "INSERT INTO probe VALUES (97, 'after commit')"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("read-only transaction");
+            connection.rollback();
+        }
+    }
+
+    /**
+     * The guard must not follow the connection back into the pool. Fineract writes through the same
+     * pool, so a restriction left behind on a returned connection would break the next thing that
+     * borrowed it — which is why the transaction, not the session, is what gets marked read-only.
+     */
+    @Test
+    @DisplayName("A connection handed back to the pool is writable again")
+    void poolConnectionIsNotLeftReadOnly() throws SQLException {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            try (Connection connection = openReadOnlyConnection()) {
+                connection.rollback();
+            }
+
+            try (Connection connection = dataSource.getConnection();
+                    Statement statement = connection.createStatement()) {
+                assertThat(connection.isReadOnly()).isFalse();
+                statement.execute("INSERT INTO probe VALUES (90, 'pool still writable')");
+                statement.execute("DELETE FROM probe WHERE id = 90");
+            }
+        }
+    }
+
+    /**
+     * The boundary a report cannot argue with, and the reason the tenant's read-only principal is
+     * worth configuring: the same escape sequence that defeats the read-only transaction is refused
+     * outright for a principal that was never granted the write.
+     */
+    @Test
+    @DisplayName("A SELECT-only principal refuses the escape the read-only transaction cannot")
+    void selectOnlyPrincipalRefusesTheEscape() throws SQLException {
+        final int rowsBefore = rowCount();
+
+        // the same sequence that defeats the read-only transaction, plus the writes it does catch
+        assertRefusedForSelectOnlyPrincipal(
+                "START TRANSACTION READ WRITE; INSERT INTO probe VALUES (94, 'escaped'); COMMIT");
+        assertRefusedForSelectOnlyPrincipal("INSERT INTO probe VALUES (93, 'plain')");
+        assertRefusedForSelectOnlyPrincipal("CREATE TABLE injected (id INT)");
+        assertRefusedForSelectOnlyPrincipal("SET ROLE postgres");
+
+        assertThat(rowCount()).isEqualTo(rowsBefore);
+    }
+
+    @Test
+    @DisplayName("A SELECT-only principal still serves the report's reads")
+    void selectOnlyPrincipalStillReads() throws SQLException {
+        try (Connection connection =
+                        DriverManager.getConnection(POSTGRES.getJdbcUrl(), READ_ONLY_USER, READ_ONLY_USER);
+                PreparedStatement statement = connection.prepareStatement("SELECT note FROM probe WHERE id = ?")) {
+            statement.setInt(1, 1);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getString(1)).isEqualTo("seed");
+            }
+        }
+    }
+
+    /**
+     * What the database alone will allow, with nothing in front of it: a session that opens a
+     * transaction of its own is no longer in the read-only one, and writes.
+     *
+     * <p>This is why the connection handed to BIRT is not this one — see {@link
+     * #guardedConnectionRefusesTheEscape()}. It is recorded here because it is the reason the guard
+     * exists, and because it is what a report gets the moment anything hands out the raw connection.
+     */
+    @Test
+    @DisplayName("Unguarded, a session that starts its own read-write transaction can write")
+    void reportCanEscapeByStartingItsOwnTransaction() throws SQLException {
+        final int rowsBefore = rowCount();
+
+        try (Connection connection = openReadOnlyConnection()) {
+            execute(connection, "COMMIT");
+            execute(connection, "START TRANSACTION READ WRITE");
+            execute(connection, "INSERT INTO probe VALUES (96, 'escaped')");
+            execute(connection, "COMMIT");
+        }
+
+        assertThat(rowCount())
+                .as("the escape is real; containment needs a read-only database user")
+                .isEqualTo(rowsBefore + 1);
+    }
+
+    /**
+     * The escape above, attempted through the connection BIRT is actually given. The guard screens
+     * the statement before the driver sees it, so the report never leaves the read-only transaction.
+     *
+     * <p>Second line, not the boundary: a script can still reach the raw connection through paths
+     * this proxy does not cover, which is why the read-only transaction and — for a deployment that
+     * wants the guarantee — a {@code SELECT}-only principal both stay.
+     */
+    @Test
+    @DisplayName("The connection BIRT is handed refuses the escape")
+    void guardedConnectionRefusesTheEscape() throws SQLException {
+        final int rowsBefore = rowCount();
+
+        try (Connection raw = openReadOnlyConnection()) {
+            final Connection guarded = connectionFactory.guard(raw);
+
+            assertRefusedByGuard(guarded, "COMMIT");
+            assertRefusedByGuard(guarded, "START TRANSACTION READ WRITE");
+            assertRefusedByGuard(guarded, "SET SESSION default_transaction_read_only = off");
+            assertRefusedByGuard(guarded, "ROLLBACK");
+
+            assertThatThrownBy(() -> guarded.prepareCall("{ call pg_sleep(0) }"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("stored procedure");
+
+            raw.rollback();
+        }
+
+        assertThat(rowCount()).isEqualTo(rowsBefore);
+    }
+
+    /**
+     * The escape attempted from the far end of the JDBC object graph, against a real driver rather
+     * than a mock: a report reads the rows it is entitled to, then walks
+     * {@code ResultSet.getStatement().getConnection()} and {@code getMetaData().getConnection()}
+     * back towards the connection underneath, and unwraps whatever it can reach.
+     *
+     * <p>Every one of those leads back to the guarded connection, so the escape sequence that
+     * {@link #reportCanEscapeByStartingItsOwnTransaction()} shows working on a raw connection is
+     * still refused at the end of the walk.
+     */
+    @Test
+    @DisplayName("The escape is refused from objects reached through the guarded connection")
+    void guardedConnectionRefusesTheEscapeReachedThroughItsOwnObjects() throws SQLException {
+        final int rowsBefore = rowCount();
+
+        try (Connection raw = openReadOnlyConnection()) {
+            final Connection guarded = connectionFactory.guard(raw);
+
+            try (Statement statement = guarded.createStatement();
+                    ResultSet resultSet = statement.executeQuery("SELECT id FROM probe WHERE id = 1")) {
+                assertThat(resultSet.next()).isTrue();
+
+                final Connection viaResultSet = resultSet.getStatement().getConnection();
+                final Connection viaMetaData = guarded.getMetaData().getConnection();
+                final Connection viaUnwrap = guarded.unwrap(Connection.class);
+
+                assertThat(viaResultSet).isSameAs(guarded);
+                assertThat(viaMetaData).isSameAs(guarded);
+                assertThat(viaUnwrap).isSameAs(guarded);
+
+                assertRefusedByGuard(viaResultSet, "COMMIT");
+                assertRefusedByGuard(viaMetaData, "START TRANSACTION READ WRITE");
+
+                // closing what the walk hands back must not close the connection underneath
+                viaResultSet.close();
+                assertThat(raw.isClosed()).isFalse();
+            }
+
+            raw.rollback();
+        }
+
+        assertThat(rowCount()).isEqualTo(rowsBefore);
+    }
+
+    /** The guard must not get in the way of the SQL reports legitimately run. */
+    @Test
+    @DisplayName("The guard leaves ordinary report SQL alone")
+    void guardedConnectionStillRunsReportSql() throws SQLException {
+        try (Connection raw = openReadOnlyConnection()) {
+            final Connection guarded = connectionFactory.guard(raw);
+
+            try (PreparedStatement statement = guarded.prepareStatement("SELECT note FROM probe WHERE id = ?")) {
+                statement.setInt(1, 1);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    assertThat(resultSet.next()).isTrue();
+                    assertThat(resultSet.getString(1)).isEqualTo("seed");
+                }
+            }
+
+            /* a column named after one of the screened words is not transaction control */
+            try (Statement statement = guarded.createStatement();
+                    ResultSet resultSet = statement.executeQuery("SELECT id AS commit_id FROM probe WHERE id = 1")) {
+                assertThat(resultSet.next()).isTrue();
+            }
+
+            raw.rollback();
+        }
+    }
+
+    /** BIRT closing the connection would return it to the pool while the report is still reading. */
+    @Test
+    @DisplayName("The guard does not let BIRT close the connection")
+    void guardedConnectionCannotBeClosedByBirt() throws SQLException {
+        try (Connection raw = openReadOnlyConnection()) {
+            final Connection guarded = connectionFactory.guard(raw);
+
+            guarded.close();
+            guarded.setReadOnly(false);
+            guarded.setAutoCommit(true);
+
+            assertThat(guarded.isClosed()).isFalse();
+            assertThat(raw.isClosed()).isFalse();
+            assertThat(raw.isReadOnly()).isTrue();
+            assertThat(raw.getAutoCommit()).isFalse();
+
+            raw.rollback();
+        }
+    }
+
+    /**
+     * A connection that is open but unrestricted is the one state a report must never be handed, so
+     * a failure to restrict has to take the connection with it rather than leak it to the pool.
+     */
+    @Test
+    @DisplayName("A connection that cannot be restricted is closed, not leaked")
+    void connectionIsClosedWhenTheRestrictionCannotBeApplied() throws SQLException {
+        final Connection connection = dataSource.getConnection();
+        /*
+         * An open connection the restriction will fail on: PostgreSQL refuses
+         * setReadOnly once a transaction is under way, which is the failure
+         * this test needs. Closing the connection first would have made the
+         * assertion below true whatever restrict did with it.
+         */
+        connection.setAutoCommit(false);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 1");
+        }
+        assertThat(connection.isClosed()).isFalse();
+
+        assertThatThrownBy(() -> connectionFactory.restrict(connection)).isInstanceOf(SQLException.class);
+
+        assertThat(connection.isClosed())
+                .as("an unrestricted connection must not be left open")
+                .isTrue();
+    }
+
+    private void assertRefusedByGuard(Connection guarded, String sql) {
+        assertThatThrownBy(() -> {
+                    try (Statement statement = guarded.createStatement()) {
+                        statement.execute(sql);
+                    }
+                })
+                .as("the guard should refuse: %s", sql)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("transaction control");
+    }
+
+    @Test
+    @DisplayName("A read-only connection still serves the SELECT a report needs")
+    void readOnlyConnectionStillReads() throws SQLException {
+        try (Connection connection = openReadOnlyConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT note FROM probe WHERE id = ?")) {
+            statement.setInt(1, 1);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getString(1)).isEqualTo("seed");
+            }
+            connection.rollback();
+        }
+    }
+
+    /**
+     * The production restriction, applied by the production code. Nothing here re-implements it: a
+     * copy would drift from what reports actually run on, and every assertion in this file would
+     * then be about the copy.
+     */
+    private Connection openReadOnlyConnection() throws SQLException {
+        return connectionFactory.restrict(dataSource.getConnection());
+    }
+
+    /**
+     * Each statement gets its own connection: the first refusal aborts the transaction, so reusing
+     * one would report "current transaction is aborted" for everything after it.
+     */
+    private void assertRejected(String sql, String expectedMessage) {
+        assertThatThrownBy(() -> {
+                    try (Connection connection = openReadOnlyConnection()) {
+                        execute(connection, sql);
+                    }
+                })
+                .as("the database should refuse: %s", sql)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
+    /** Fresh connection per statement: the first refusal aborts the transaction for the rest. */
+    private void assertRefusedForSelectOnlyPrincipal(String sql) {
+        assertThatThrownBy(() -> {
+                    try (Connection connection =
+                                    DriverManager.getConnection(POSTGRES.getJdbcUrl(), READ_ONLY_USER, READ_ONLY_USER);
+                            Statement statement = connection.createStatement()) {
+                        statement.execute(sql);
+                    }
+                })
+                .as("a SELECT-only principal should be refused: %s", sql)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("permission denied");
+    }
+
+    private void execute(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    private int rowCount() {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM probe")) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static LocalContainerEntityManagerFactoryBean buildEntityManagerFactory(HikariDataSource dataSource) {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("eclipselink.weaving", "false");
+        properties.put("eclipselink.ddl-generation", "none");
+        properties.put("eclipselink.logging.level", "OFF");
+
+        final LocalContainerEntityManagerFactoryBean bean = new LocalContainerEntityManagerFactoryBean();
+        bean.setDataSource(dataSource);
+        bean.setPersistenceUnitName("birt-readonly-probe");
+        bean.setPackagesToScan("org.apache.fineract.infrastructure.report.integration.noentities");
+        bean.setJpaVendorAdapter(new EclipseLinkJpaVendorAdapter());
+        bean.setJpaPropertyMap(properties);
+        bean.afterPropertiesSet();
+        return bean;
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtReadOnlyPrincipalIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtReadOnlyPrincipalIntegrationTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.containers.Container;
+
+/**
+ * Runs a shipped report end to end with the tenant's read-only database principal configured, the
+ * arrangement that actually contains a hostile {@code .rptdesign}.
+ *
+ * <p>Point of the test: a principal granted only {@code SELECT} is worthless if BIRT cannot render
+ * through it. This checks the report still comes back, that the plugin really connected as that
+ * principal, and that the principal is one the database refuses writes from.
+ */
+@DisplayName("BIRT execution as the tenant's read-only principal")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class BirtReadOnlyPrincipalIntegrationTest extends BirtIntegrationTestBase {
+
+    private static final String READ_ONLY_USER = "birt_ro";
+
+    /** A table the shipped report reads, used to take the principal's access away and put it back. */
+    private static final String REPORT_TABLE = "m_loan";
+
+    /**
+     * {@code readonly_schema_password} is decrypted exactly like {@code schema_password}, so it has
+     * to be stored the same way — a plaintext value there fails to decrypt and the report fails
+     * closed. The role therefore gets the tenant's own database password and the column gets the
+     * tenant's existing encrypted blob, which keeps the test free of the master password.
+     */
+    @BeforeAll
+    void configureReadOnlyPrincipal() {
+        run(
+                "fineract_default",
+                "CREATE ROLE " + READ_ONLY_USER + " LOGIN PASSWORD 'postgres';"
+                        + "GRANT CONNECT ON DATABASE fineract_default TO " + READ_ONLY_USER + ";"
+                        + "GRANT USAGE ON SCHEMA public TO " + READ_ONLY_USER + ";"
+                        + "GRANT SELECT ON ALL TABLES IN SCHEMA public TO " + READ_ONLY_USER + ";");
+
+        run(
+                "fineract_tenants",
+                "UPDATE tenant_server_connections SET readonly_schema_server = 'db',"
+                        + " readonly_schema_server_port = '5432',"
+                        + " readonly_schema_name = 'fineract_default',"
+                        + " readonly_schema_username = '" + READ_ONLY_USER + "',"
+                        + " readonly_schema_password = schema_password;");
+    }
+
+    /**
+     * The containers are static and shared, and Failsafe runs every integration test class in one
+     * JVM. Left as it is, this class would quietly redirect every report run by every class after it
+     * through {@code birt_ro}, and the first one that needs to write would fail somewhere unrelated.
+     */
+    @AfterAll
+    void restoreTenantConnection() {
+        run(
+                "fineract_tenants",
+                "UPDATE tenant_server_connections SET readonly_schema_server = NULL,"
+                        + " readonly_schema_server_port = NULL,"
+                        + " readonly_schema_name = NULL,"
+                        + " readonly_schema_username = NULL,"
+                        + " readonly_schema_password = NULL;");
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Should render a shipped report through the SELECT-only principal")
+    void shouldRenderReportAsReadOnlyPrincipal() {
+        runReport().then().statusCode(200).contentType("text/csv");
+    }
+
+    /**
+     * The test that makes the one above mean something.
+     *
+     * <p>A 200 and a CSV content type would come back just as happily if the plugin had ignored the
+     * configured principal and used the ordinary tenant connection — which is the failure worth
+     * catching. Taking {@code SELECT} away from {@code birt_ro} alone and watching the same request
+     * start failing shows whose privileges the report is actually running under.
+     */
+    @Test
+    @Order(2)
+    @DisplayName("The report runs under the configured principal's privileges, not the tenant's")
+    void reportUsesTheConfiguredPrincipalsPrivileges() {
+        run("fineract_default", "REVOKE SELECT ON " + REPORT_TABLE + " FROM " + READ_ONLY_USER + ";");
+        try {
+            final Response response = runReport();
+            assertThat(response.statusCode())
+                    .as("removing birt_ro's SELECT must break the report, or it never ran as birt_ro")
+                    .isNotEqualTo(200);
+            assertThat(response.getBody().asString()).containsIgnoringCase("permission denied");
+        } finally {
+            run("fineract_default", "GRANT SELECT ON " + REPORT_TABLE + " TO " + READ_ONLY_USER + ";");
+        }
+    }
+
+    /** Proves the principal the report ran as is genuinely unable to write. */
+    @Test
+    @Order(3)
+    @DisplayName("The configured principal is refused every write by the database")
+    void configuredPrincipalCannotWrite() {
+        final Container.ExecResult result = execPostgres(
+                "psql",
+                "-U",
+                READ_ONLY_USER,
+                "-d",
+                "fineract_default",
+                "-c",
+                "INSERT INTO m_office (id, name, hierarchy, opening_date) VALUES (999, 'evil', '.', now())");
+
+        assertThat(result.getStderr()).contains("permission denied");
+    }
+
+    private Response runReport() {
+        return given().spec(requestSpec())
+                .header("Fineract-Platform-TenantId", "default")
+                .header("Authorization", "Basic bWlmb3M6cGFzc3dvcmQ=")
+                .queryParam("tenantIdentifier", "default")
+                .queryParam("output-type", "CSV")
+                .queryParam("locale", "en")
+                .queryParam("dateFormat", "dd MMMM yyyy")
+                .queryParam("R_branch", "1")
+                .queryParam("R_loanOfficer", "-1")
+                .queryParam("R_loanPurposeId", "-1")
+                .queryParam("R_loanProductId", "-1")
+                .queryParam("R_fundId", "-1")
+                .queryParam("R_currencyId", "-1")
+                .when()
+                .get("/fineract-provider/api/v1/runreports/Active_Loans_Details");
+    }
+
+    private RequestSpecification requestSpec() {
+        return new RequestSpecBuilder()
+                .setBaseUri("https://" + FINERACT.getHost() + ":" + getFineractPort())
+                .setRelaxedHTTPSValidation()
+                .build();
+    }
+
+    private void run(String database, String sql) {
+        final Container.ExecResult result = execPostgres("psql", "-U", "postgres", "-d", database, "-c", sql);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException("Setup SQL failed: " + result.getStderr());
+        }
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReadOnlyConnectionFactoryTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReadOnlyConnectionFactoryTest.java
@@ -1,0 +1,501 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor;
+import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Covers the connection restriction itself. What it looks like against a real database — including
+ * which writes the database then refuses, and where the restriction stops — is in {@code
+ * BirtConnectionReadOnlyIntegrationTest}, which drives this same class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BirtReadOnlyConnectionFactory Tests")
+class BirtReadOnlyConnectionFactoryTest {
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private DatabasePasswordEncryptor databasePasswordEncryptor;
+
+    private BirtPluginProperties birtProperties;
+    private BirtReadOnlyConnectionFactory factory;
+
+    private Connection connection;
+    private Statement statement;
+    private FineractPlatformTenantConnection tenantConnection;
+    private MockedStatic<ThreadLocalContextUtil> mockedThreadLocalContextUtil;
+    private MockedStatic<org.apache.fineract.infrastructure.report.util.DataSourceUtils> mockedDataSourceUtils;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        birtProperties = new BirtPluginProperties();
+        factory = spy(new BirtReadOnlyConnectionFactory(dataSource, databasePasswordEncryptor, birtProperties));
+
+        connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        statement = mock(Statement.class);
+        lenient()
+                .when(connection.getMetaData().getURL())
+                .thenReturn("jdbc:postgresql://localhost:5432/fineract_tenant");
+        lenient().when(connection.createStatement()).thenReturn(statement);
+        lenient().when(dataSource.getConnection()).thenReturn(connection);
+
+        final FineractPlatformTenant tenant = mock(FineractPlatformTenant.class);
+        tenantConnection = mock(FineractPlatformTenantConnection.class);
+        lenient().when(tenant.getConnection()).thenReturn(tenantConnection);
+
+        mockedThreadLocalContextUtil = mockStatic(ThreadLocalContextUtil.class);
+        mockedThreadLocalContextUtil.when(ThreadLocalContextUtil::getTenant).thenReturn(tenant);
+
+        mockedDataSourceUtils = mockStatic(org.apache.fineract.infrastructure.report.util.DataSourceUtils.class);
+        mockedDataSourceUtils
+                .when(() -> org.apache.fineract.infrastructure.report.util.DataSourceUtils.getDriverClassName(any()))
+                .thenReturn("org.postgresql.Driver");
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedThreadLocalContextUtil.close();
+        mockedDataSourceUtils.close();
+    }
+
+    @Test
+    @DisplayName("Should hand out a connection the database will not accept writes on")
+    void shouldRestrictTheConnection() throws Exception {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("");
+
+        assertSame(connection, factory.open());
+
+        final InOrder inOrder = inOrder(connection, statement);
+        inOrder.verify(connection).setReadOnly(true);
+        inOrder.verify(connection).setAutoCommit(false);
+        // pins the read-only state: a database stops accepting READ WRITE once a query has run
+        inOrder.verify(statement).execute("SELECT 1");
+
+        // PostgreSQL's driver opens the transaction read-only by itself
+        verify(statement, never()).execute("START TRANSACTION READ ONLY");
+    }
+
+    @Test
+    @DisplayName("Should open the read-only transaction explicitly on MySQL/MariaDB")
+    void shouldStartReadOnlyTransactionExplicitlyOnMariaDb() throws Exception {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("");
+        when(connection.getMetaData().getURL()).thenReturn("jdbc:mariadb://localhost:3306/fineract_tenant");
+
+        factory.open();
+
+        final InOrder inOrder = inOrder(connection, statement);
+        inOrder.verify(connection).setAutoCommit(false);
+        // MariaDB's driver treats setReadOnly as a routing hint, so the transaction is opened by hand
+        inOrder.verify(statement).execute("START TRANSACTION READ ONLY");
+        inOrder.verify(statement).execute("SELECT 1");
+    }
+
+    /**
+     * The check is for the two drivers known to need the statement, not for everything that is not
+     * PostgreSQL. A URL nobody has checked — {@code jdbc:aws-wrapper:postgresql} is one Fineract
+     * already supports — gets its driver's behaviour rather than a statement guessed on its behalf.
+     */
+    @Test
+    @DisplayName("Should leave an unrecognised database to its own driver")
+    void shouldNotIssueTheStatementForAnUnrecognisedDatabase() throws Exception {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("");
+        when(connection.getMetaData().getURL())
+                .thenReturn("jdbc:aws-wrapper:postgresql://cluster.rds.amazonaws.com:5432/fineract_tenant");
+
+        factory.open();
+
+        verify(connection).setReadOnly(true);
+        verify(statement, never()).execute("START TRANSACTION READ ONLY");
+    }
+
+    /** Open but unrestricted is the one state a report must never be handed. */
+    @Test
+    @DisplayName("Should close the connection when the restriction cannot be applied")
+    void shouldCloseTheConnectionWhenItCannotBeRestricted() throws Exception {
+        doThrow(new SQLException("connection closed")).when(connection).setReadOnly(true);
+
+        assertThrows(SQLException.class, () -> factory.restrict(connection));
+
+        verify(connection).close();
+    }
+
+    @Test
+    @DisplayName("Should run reports through a pool for the tenant's read-only principal")
+    void shouldUseReadOnlyPrincipalWhenConfigured() throws Exception {
+        final HikariDataSource pool = mock(HikariDataSource.class);
+        when(pool.getConnection()).thenReturn(connection);
+        doReturn(pool).when(factory).buildReadOnlyPool(anyString(), anyString(), anyString());
+
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("encrypted_ro ");
+        when(tenantConnection.getReadOnlySchemaServer()).thenReturn("replica");
+        when(tenantConnection.getReadOnlySchemaServerPort()).thenReturn("5432");
+        when(tenantConnection.getReadOnlySchemaName()).thenReturn("fineract_default");
+        when(databasePasswordEncryptor.decrypt("encrypted_ro")).thenReturn("ro_pass");
+
+        factory.open();
+
+        verify(factory).buildReadOnlyPool("jdbc:postgresql://replica:5432/fineract_default", "birt_ro", "ro_pass");
+        verify(dataSource, never()).getConnection();
+    }
+
+    /**
+     * The reason the pool exists. A connection opened per report leaves the database's own connection
+     * limit as the only bound on how many reports can be in flight, and exhausting that takes down
+     * all of Fineract rather than only reporting.
+     */
+    @Test
+    @DisplayName("Should build the read-only pool once and reuse it")
+    void shouldReuseTheReadOnlyPool() throws Exception {
+        final HikariDataSource pool = mock(HikariDataSource.class);
+        when(pool.getConnection()).thenReturn(connection);
+        doReturn(pool).when(factory).buildReadOnlyPool(anyString(), anyString(), anyString());
+
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("encrypted_ro");
+        when(tenantConnection.getReadOnlySchemaName()).thenReturn("fineract_default");
+        when(databasePasswordEncryptor.decrypt("encrypted_ro")).thenReturn("ro_pass");
+
+        factory.open();
+        factory.open();
+        factory.open();
+
+        verify(factory).buildReadOnlyPool(anyString(), anyString(), anyString());
+    }
+
+    /**
+     * A pool holds the password it was built with for as long as it lives, so reusing one across a
+     * rotation would keep reports working until the pool needed a new physical connection and then
+     * fail to authenticate until Fineract was restarted.
+     */
+    @Test
+    @DisplayName("Should replace and close the pool when the read-only password is rotated")
+    void shouldReplaceTheReadOnlyPoolWhenThePasswordIsRotated() throws Exception {
+        final HikariDataSource firstPool = mock(HikariDataSource.class);
+        final HikariDataSource secondPool = mock(HikariDataSource.class);
+        when(firstPool.getConnection()).thenReturn(connection);
+        when(secondPool.getConnection()).thenReturn(connection);
+        doReturn(firstPool, secondPool).when(factory).buildReadOnlyPool(anyString(), anyString(), anyString());
+
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaName()).thenReturn("fineract_default");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("encrypted_old", "encrypted_new");
+        when(databasePasswordEncryptor.decrypt("encrypted_old")).thenReturn("old_pass");
+        when(databasePasswordEncryptor.decrypt("encrypted_new")).thenReturn("new_pass");
+
+        factory.open();
+        factory.open();
+
+        final InOrder inOrder = inOrder(factory);
+        inOrder.verify(factory).buildReadOnlyPool(anyString(), eq("birt_ro"), eq("old_pass"));
+        inOrder.verify(factory).buildReadOnlyPool(anyString(), eq("birt_ro"), eq("new_pass"));
+        // the superseded pool is closed once the replacement is in the map, not before
+        verify(firstPool).close();
+        verify(secondPool, never()).close();
+    }
+
+    /** A pool the rotation replaced must not be left open holding connections nobody will use. */
+    @Test
+    @DisplayName("Should close every pool it built on shutdown")
+    void shouldCloseTheReadOnlyPoolsOnShutdown() throws Exception {
+        final HikariDataSource pool = mock(HikariDataSource.class);
+        when(pool.getConnection()).thenReturn(connection);
+        doReturn(pool).when(factory).buildReadOnlyPool(anyString(), anyString(), anyString());
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaName()).thenReturn("fineract_default");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("encrypted_ro");
+        when(databasePasswordEncryptor.decrypt("encrypted_ro")).thenReturn("ro_pass");
+        factory.open();
+
+        factory.closeReadOnlyPools();
+
+        verify(pool).close();
+    }
+
+    /**
+     * The pool is built on first use rather than inside the map's remapping function, because
+     * starting one opens a physical connection. A build that fails therefore has to leave an entry a
+     * later report can retry, not a poisoned one.
+     */
+    @Test
+    @DisplayName("Should retry a pool that failed to build, on the next report")
+    void shouldRetryAPoolThatFailedToBuild() throws Exception {
+        final HikariDataSource pool = mock(HikariDataSource.class);
+        when(pool.getConnection()).thenReturn(connection);
+        doThrow(new PlatformDataIntegrityException("error.msg.reporting.sql.error", "the database was down"))
+                .doReturn(pool)
+                .when(factory)
+                .buildReadOnlyPool(anyString(), anyString(), anyString());
+        configureReadOnlyPrincipal();
+
+        assertThrows(PlatformDataIntegrityException.class, () -> factory.open());
+        assertSame(connection, factory.open());
+
+        verify(factory, times(2)).buildReadOnlyPool(anyString(), anyString(), anyString());
+    }
+
+    /** Nothing may close a pool that never opened, and shutdown must not build one to close it. */
+    @Test
+    @DisplayName("Should not close a pool that was never built")
+    void shouldNotCloseAPoolThatWasNeverBuilt() {
+        doThrow(new PlatformDataIntegrityException("error.msg.reporting.sql.error", "the database was down"))
+                .when(factory)
+                .buildReadOnlyPool(anyString(), anyString(), anyString());
+        configureReadOnlyPrincipal();
+        assertThrows(PlatformDataIntegrityException.class, () -> factory.open());
+
+        assertDoesNotThrow(factory::closeReadOnlyPools);
+
+        verify(factory, times(1)).buildReadOnlyPool(anyString(), anyString(), anyString());
+    }
+
+    private void configureReadOnlyPrincipal() {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaName()).thenReturn("fineract_default");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("encrypted_ro");
+        when(databasePasswordEncryptor.decrypt("encrypted_ro")).thenReturn("ro_pass");
+    }
+
+    @Test
+    @DisplayName("Should fall back to the tenant pool when no read-only principal is configured")
+    void shouldFallBackToTenantPoolWhenNoReadOnlyPrincipal() throws Exception {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("");
+
+        factory.open();
+
+        verify(dataSource).getConnection();
+    }
+
+    /**
+     * Nothing documents that the column has to hold an encrypted value, so a blank or plaintext one
+     * is the first thing an operator configuring this hits. Left to the decrypt failure it reaches
+     * them as "Unknown SQL error", naming neither the column nor what is wrong with it.
+     */
+    @Test
+    @DisplayName("Should name the column when the read-only password is missing")
+    void shouldNameTheColumnWhenTheReadOnlyPasswordIsMissing() {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("  ");
+
+        final PlatformDataIntegrityException ex = assertThrows(PlatformDataIntegrityException.class, factory::open);
+
+        assertEquals("error.msg.reporting.readonly.password.missing", ex.getGlobalisationMessageCode());
+    }
+
+    @Test
+    @DisplayName("Should name the column when the read-only password is not encrypted")
+    void shouldNameTheColumnWhenTheReadOnlyPasswordIsNotEncrypted() {
+        when(tenantConnection.getReadOnlySchemaUsername()).thenReturn("birt_ro");
+        when(tenantConnection.getReadOnlySchemaPassword()).thenReturn("plaintext");
+        when(databasePasswordEncryptor.decrypt("plaintext")).thenThrow(new IllegalArgumentException("bad padding"));
+
+        final PlatformDataIntegrityException ex = assertThrows(PlatformDataIntegrityException.class, factory::open);
+
+        assertEquals("error.msg.reporting.readonly.password.not.encrypted", ex.getGlobalisationMessageCode());
+    }
+
+    @Test
+    @DisplayName("Should ignore BIRT's attempts to lift the restriction or close the connection")
+    void shouldIgnoreBirtLiftingTheRestriction() throws Exception {
+        final Connection guarded = factory.guard(connection);
+
+        guarded.close();
+        guarded.setReadOnly(false);
+        guarded.setAutoCommit(true);
+        guarded.commit();
+
+        verify(connection, never()).close();
+        verify(connection, never()).setReadOnly(false);
+        verify(connection, never()).setAutoCommit(true);
+        verify(connection, never()).commit();
+    }
+
+    @Test
+    @DisplayName("Should refuse the SQL a report would use to leave the read-only transaction")
+    void shouldRefuseTransactionControl() {
+        final Connection guarded = factory.guard(connection);
+
+        assertRefused(guarded, "COMMIT");
+        assertRefused(guarded, "commit;");
+        assertRefused(guarded, "ROLLBACK");
+        assertRefused(guarded, "BEGIN");
+        assertRefused(guarded, "START TRANSACTION READ WRITE");
+        assertRefused(guarded, "SET TRANSACTION READ WRITE");
+        assertRefused(guarded, "SET SESSION default_transaction_read_only = off");
+    }
+
+    @Test
+    @DisplayName("Should refuse a stored procedure call outright")
+    void shouldRefuseStoredProcedureCalls() {
+        final Connection guarded = factory.guard(connection);
+
+        assertThrows(SQLException.class, () -> guarded.prepareCall("{ call do_something() }"));
+    }
+
+    /** The screening must not catch the SQL reports legitimately run. */
+    @Test
+    @DisplayName("Should leave ordinary report SQL alone")
+    void shouldLeaveOrdinaryReportSqlAlone() throws Exception {
+        final Connection guarded = factory.guard(connection);
+
+        guarded.prepareStatement("SELECT l.commit_date, o.beginning_balance FROM m_loan l JOIN m_office o ON true");
+
+        verify(connection)
+                .prepareStatement("SELECT l.commit_date, o.beginning_balance FROM m_loan l JOIN m_office o ON true");
+    }
+
+    /**
+     * Without this, a report holding a statement could reach the unguarded connection through it and
+     * commit, or start a read-write transaction of its own.
+     */
+    @Test
+    @DisplayName("Should hand back the guarded connection from a statement, not the real one")
+    void shouldGuardTheConnectionReachedThroughAStatement() throws Exception {
+        final Connection guarded = factory.guard(connection);
+
+        final Connection reached = guarded.createStatement().getConnection();
+
+        assertSame(guarded, reached);
+        reached.close();
+        verify(connection, never()).close();
+        assertThrows(SQLException.class, () -> reached.prepareStatement("COMMIT"));
+    }
+
+    /**
+     * {@code DatabaseMetaData.getConnection()} is the shortest way back to the physical connection,
+     * and BIRT reads metadata on every report.
+     */
+    @Test
+    @DisplayName("Should hand back the guarded connection from database metadata")
+    void shouldGuardTheConnectionReachedThroughMetaData() throws Exception {
+        final Connection guarded = factory.guard(connection);
+
+        final Connection reached = guarded.getMetaData().getConnection();
+
+        assertSame(guarded, reached);
+        reached.close();
+        verify(connection, never()).close();
+        assertThrows(SQLException.class, () -> reached.prepareStatement("COMMIT"));
+    }
+
+    /**
+     * The full traversal a report can walk from the rows it is entitled to read:
+     * {@code executeQuery(...).getStatement().getConnection()}.
+     */
+    @Test
+    @DisplayName("Should hand back the guarded connection from a result set's statement")
+    void shouldGuardTheConnectionReachedThroughAResultSet() throws Exception {
+        final Connection guarded = factory.guard(connection);
+        when(statement.executeQuery("SELECT 1")).thenReturn(mock(ResultSet.class));
+
+        final ResultSet resultSet = guarded.createStatement().executeQuery("SELECT 1");
+        final Connection reached = resultSet.getStatement().getConnection();
+
+        assertSame(guarded, reached);
+        reached.close();
+        verify(connection, never()).close();
+        assertThrows(SQLException.class, () -> reached.prepareStatement("COMMIT"));
+    }
+
+    /** A metadata result set was produced by no statement, which JDBC defines as null. */
+    @Test
+    @DisplayName("Should not hand back a statement from a metadata result set")
+    void shouldGuardTheStatementReachedThroughAMetaDataResultSet() throws Exception {
+        final Connection guarded = factory.guard(connection);
+        final DatabaseMetaData metaData = guarded.getMetaData();
+        final ResultSet tables = mock(ResultSet.class);
+        // a driver is free to hand back an internal statement here, and that statement knows the
+        // connection; lenient because the wrapper answering getStatement() is what leaves it unused
+        lenient().when(tables.getStatement()).thenReturn(statement);
+        when(connection.getMetaData().getTables(null, null, "%", null)).thenReturn(tables);
+
+        assertNull(metaData.getTables(null, null, "%", null).getStatement());
+    }
+
+    /** unwrap exists to reach the implementation behind a wrapper, which is what must not leak. */
+    @Test
+    @DisplayName("Should refuse to unwrap any guarded object to the object underneath")
+    void shouldRefuseToUnwrapToThePhysicalConnection() throws Exception {
+        final Connection guarded = factory.guard(connection);
+        when(statement.executeQuery("SELECT 1")).thenReturn(mock(ResultSet.class));
+        final Statement guardedStatement = guarded.createStatement();
+        final ResultSet guardedResultSet = guardedStatement.executeQuery("SELECT 1");
+
+        assertSame(guarded, guarded.unwrap(Connection.class));
+        assertSame(guardedStatement, guardedStatement.unwrap(Statement.class));
+        assertSame(guardedResultSet, guardedResultSet.unwrap(ResultSet.class));
+        assertSame(guarded, guarded.getMetaData().unwrap(DatabaseMetaData.class).getConnection());
+
+        assertThrows(SQLException.class, () -> guarded.unwrap(PhysicalConnection.class));
+        assertThrows(SQLException.class, () -> guardedStatement.unwrap(PhysicalConnection.class));
+    }
+
+    /** isWrapperFor has to agree with unwrap, or a caller is told to expect what it cannot get. */
+    @Test
+    @DisplayName("Should report isWrapperFor consistently with unwrap")
+    void shouldKeepIsWrapperForConsistentWithUnwrap() throws Exception {
+        final Connection guarded = factory.guard(connection);
+
+        assertTrue(guarded.isWrapperFor(Connection.class));
+        assertFalse(guarded.isWrapperFor(PhysicalConnection.class));
+        assertTrue(guarded.createStatement().isWrapperFor(Statement.class));
+        assertFalse(guarded.createStatement().isWrapperFor(PhysicalConnection.class));
+    }
+
+    /** Stands in for a driver's own connection interface, the thing unwrap is usually asked for. */
+    private interface PhysicalConnection extends Connection {}
+
+    private void assertRefused(Connection guarded, String sql) {
+        assertThrows(SQLException.class, () -> guarded.prepareStatement(sql), "should refuse: " + sql);
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportLoaderTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportLoaderTest.java
@@ -7,10 +7,14 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
@@ -51,9 +55,19 @@ class BirtReportLoaderTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * The reports directory is a subdirectory, so that "outside" in these tests means outside it but
+     * still inside what JUnit created and will delete. Resolving against the parent put fixed
+     * filenames in the shared temporary root, where a parallel class could collide with them and
+     * nothing would clean them up.
+     */
+    private Path reportsDir;
+
     @BeforeEach
-    void setUp() throws EngineException {
-        when(birtProperties.getReportsPath()).thenReturn(tempDir.toString());
+    void setUp() throws EngineException, java.io.IOException {
+        reportsDir = tempDir.resolve("reports");
+        Files.createDirectories(reportsDir);
+        when(birtProperties.getReportsPath()).thenReturn(reportsDir.toString());
 
         // Mock error handler - will be used only in failure cases
         when(reportErrorHandler.reportError(anyString(), anyString())).thenAnswer(invocation -> {
@@ -71,7 +85,7 @@ class BirtReportLoaderTest {
     @Test
     @DisplayName("Should load report successfully when file exists")
     void shouldLoadReportSuccessfully() throws Exception {
-        Path reportPath = tempDir.resolve("sample.rptdesign");
+        Path reportPath = reportsDir.resolve("sample.rptdesign");
         Files.writeString(reportPath, "<?xml version=\"1.0\"?><report></report>");
 
         IReportRunnable report = reportLoader.loadReport("sample", null);
@@ -90,10 +104,93 @@ class BirtReportLoaderTest {
     @Test
     @DisplayName("Should prefer locale-specific report first")
     void shouldTryLocaleSpecificReportFirst() throws Exception {
-        Path esReport = tempDir.resolve("sample_es.rptdesign");
+        Path esReport = reportsDir.resolve("sample_es.rptdesign");
         Files.writeString(esReport, "<?xml version=\"1.0\"?><report lang=\"es\"></report>");
 
         IReportRunnable report = reportLoader.loadReport("sample", java.util.Locale.forLanguageTag("es"));
         assertNotNull(report);
+    }
+
+    @Test
+    @DisplayName("Should reject a report name that climbs out of the reports directory")
+    void shouldRejectReportNameEscapingTheReportsDirectory() throws Exception {
+        Path outside = tempDir.resolve("outside.rptdesign");
+        Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("../outside", null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+        verify(reportEngine, never()).openReportDesign(anyString());
+    }
+
+    @Test
+    @DisplayName("Should reject an absolute report name")
+    void shouldRejectAbsoluteReportName() throws Exception {
+        Path outside = tempDir.resolve("absolute.rptdesign");
+        Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
+
+        String absoluteName = outside.toString().replace(".rptdesign", "");
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport(absoluteName, null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+        verify(reportEngine, never()).openReportDesign(anyString());
+    }
+
+    /**
+     * Normalising the text of the path is not enough on its own: a link inside the reports directory
+     * resolves to wherever it points, and only following it shows that.
+     */
+    @Test
+    @DisplayName("Should reject a report that is a symlink out of the reports directory")
+    void shouldRejectSymlinkEscapingTheReportsDirectory() throws Exception {
+        Path outside = tempDir.resolve("linked.rptdesign");
+        Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
+
+        try {
+            Files.createSymbolicLink(reportsDir.resolve("linked.rptdesign"), outside);
+        } catch (UnsupportedOperationException | java.io.IOException e) {
+            org.junit.jupiter.api.Assumptions.abort("symlinks are not available here: " + e.getMessage());
+        }
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("linked", null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+        verify(reportEngine, never()).openReportDesign(anyString());
+    }
+
+    /**
+     * The reports directory comes from {@code c_external_service_properties}, so a value an
+     * administrator stored can fail to be a path at all. That has to reach the caller as the same
+     * not-found every other bad path does, not as an InvalidPathException escaping the loader.
+     */
+    @Test
+    @DisplayName("Should reject a configured reports directory that is not a path")
+    void shouldRejectAConfiguredReportsDirectoryThatIsNotAPath() {
+        when(birtProperties.getReportsPath()).thenReturn("not\u0000a\u0000path");
+        // this path reports through the overload that carries the cause, so it needs its own stub
+        when(reportErrorHandler.reportError(anyString(), anyString(), any())).thenAnswer(invocation -> {
+            final String code = invocation.getArgument(0);
+            final String message = invocation.getArgument(1);
+            throw new PlatformDataIntegrityException(code, message);
+        });
+
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("sample", null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+    }
+
+    @Test
+    @DisplayName("Should not disclose the server filesystem path when a report is missing")
+    void shouldNotLeakFilesystemPathWhenReportIsMissing() {
+        PlatformDataIntegrityException ex =
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("missing", null));
+
+        assertFalse(ex.getDefaultUserMessage().contains(reportsDir.toString()));
+        assertFalse(ex.getDefaultUserMessage().contains(".rptdesign"));
     }
 }

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportingProcessServiceImplTest.java
@@ -8,6 +8,8 @@ package org.apache.fineract.infrastructure.report.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,9 +17,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,15 +30,12 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
-import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
-import org.apache.fineract.infrastructure.core.service.database.DatabasePasswordEncryptor;
 import org.apache.fineract.infrastructure.dataqueries.data.ReportExportType;
 import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
 import org.apache.fineract.infrastructure.report.renderer.BirtRenderer;
@@ -49,11 +50,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
@@ -102,19 +103,17 @@ class BirtReportingProcessServiceImplTest {
     private BirtSqlDialectInterpolator sqlDialectInterpolator;
 
     @Mock
-    private DatabasePasswordEncryptor databasePasswordEncryptor;
-
-    @Mock
     private BirtRenderer xmlRenderer;
 
     @Mock
     private ReportSecurityService reportSecurityService;
 
+    @Mock
+    private BirtReadOnlyConnectionFactory connectionFactory;
+
     @InjectMocks
     private BirtReportingProcessServiceImpl service;
 
-    private MockedStatic<DataSourceUtils> mockedDataSourceUtils;
-    private MockedStatic<ThreadLocalContextUtil> mockedThreadLocalContextUtil;
     private MockedStatic<org.apache.fineract.infrastructure.report.util.DataSourceUtils> mockedReportDataSourceUtils;
 
     private Connection mockConnection;
@@ -137,26 +136,8 @@ class BirtReportingProcessServiceImplTest {
         DatabaseMetaData metaData = mock(DatabaseMetaData.class);
         lenient().when(mockConnection.getMetaData()).thenReturn(metaData);
         lenient().when(metaData.getURL()).thenReturn("jdbc:postgresql://localhost:5432/fineract_tenant");
-
-        mockedDataSourceUtils = mockStatic(DataSourceUtils.class);
-        mockedDataSourceUtils
-                .when(() -> DataSourceUtils.getConnection(any(DataSource.class)))
-                .thenReturn(mockConnection);
-        mockedDataSourceUtils
-                .when(() -> DataSourceUtils.releaseConnection(any(Connection.class), any(DataSource.class)))
-                .thenAnswer(i -> null);
-
-        // Mock Tenant Context
-        FineractPlatformTenant tenant = mock(FineractPlatformTenant.class);
-        FineractPlatformTenantConnection tenantConnection = mock(FineractPlatformTenantConnection.class);
-        lenient().when(tenant.getConnection()).thenReturn(tenantConnection);
-        lenient().when(tenant.getTenantIdentifier()).thenReturn("default");
-        lenient().when(tenantConnection.getSchemaUsername()).thenReturn("tenant_user");
-        lenient().when(tenantConnection.getSchemaPassword()).thenReturn("encrypted_pass ");
-        lenient().when(databasePasswordEncryptor.decrypt("encrypted_pass")).thenReturn("decrypted_pass");
-
-        mockedThreadLocalContextUtil = mockStatic(ThreadLocalContextUtil.class);
-        mockedThreadLocalContextUtil.when(ThreadLocalContextUtil::getTenant).thenReturn(tenant);
+        lenient().when(mockConnection.createStatement()).thenReturn(mock(Statement.class));
+        lenient().when(connectionFactory.open()).thenReturn(mockConnection);
 
         mockedReportDataSourceUtils = mockStatic(org.apache.fineract.infrastructure.report.util.DataSourceUtils.class);
         mockedReportDataSourceUtils
@@ -166,12 +147,6 @@ class BirtReportingProcessServiceImplTest {
 
     @AfterEach
     void tearDown() {
-        if (mockedDataSourceUtils != null) {
-            mockedDataSourceUtils.close();
-        }
-        if (mockedThreadLocalContextUtil != null) {
-            mockedThreadLocalContextUtil.close();
-        }
         if (mockedReportDataSourceUtils != null) {
             mockedReportDataSourceUtils.close();
         }
@@ -325,8 +300,14 @@ class BirtReportingProcessServiceImplTest {
         // Verify the setConnectionDetail logic successfully populated the appContext
         assertEquals("org.postgresql.Driver", appContext.get("OdaJDBCDriverClass"));
         assertEquals("jdbc:postgresql://localhost:5432/fineract_tenant", appContext.get("OdaJDBCDriverUrl"));
-        assertEquals("tenant_user", appContext.get("OdaJDBCDriverUser"));
-        assertEquals("decrypted_pass", appContext.get("OdaJDBCDriverPassword"));
+
+        /*
+         * No credentials: BIRT takes the pass-in connection and returns before
+         * reading a user or password, so publishing them would only expose the
+         * tenant's decrypted database password to report scripts.
+         */
+        assertNull(appContext.get("OdaJDBCDriverUser"));
+        assertNull(appContext.get("OdaJDBCDriverPassword"));
 
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(
                 reportExecutionFactory, sqlDialectInterpolator, parameterMapper, contextInjector, task, pdfRenderer);
@@ -412,6 +393,110 @@ class BirtReportingProcessServiceImplTest {
         assertThrows(PlatformDataIntegrityException.class, () -> service.processRequest("sample", queryParams("PDF")));
 
         verify(task).close();
+    }
+
+    /**
+     * Dropped rather than rejected. The value never reached the report anyway — the parameter mapper
+     * skips these names and the context injector overwrites them — so failing the request would turn
+     * a no-op into an outage for stored report mailing jobs that still carry {@code R_userhierarchy}.
+     */
+    @Test
+    @DisplayName("Should drop client-supplied server-managed parameters, whatever their casing")
+    void shouldDropClientSuppliedServerManagedParameters() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("R_userid", "1");
+        params.add("R_userHierarchy", ".");
+        params.add("R_officeId", "1");
+
+        Map<String, String> result = service.getReportParams("sample", params);
+
+        assertEquals(Map.of("officeId", "1"), result);
+    }
+
+    @Test
+    @DisplayName("Should verify the report grant before anything is loaded or executed")
+    void shouldCheckPermissionBeforeExecuting() {
+        doThrow(new PlatformDataIntegrityException("error.denied", "denied"))
+                .when(reportSecurityService)
+                .checkReportExecutionPermission("sample");
+
+        assertThrows(PlatformDataIntegrityException.class, () -> service.processRequest("sample", queryParams("PDF")));
+
+        verify(reportExecutionFactory, never()).createExecutionRunnable(anyString(), any());
+    }
+
+    /**
+     * The connection itself is {@code BirtReadOnlyConnectionFactory}'s business, and is covered
+     * there. What belongs here is that the service asks it for one, gives BIRT only the guarded
+     * view, and hands the connection back however the run ends.
+     */
+    @Test
+    @DisplayName("Should run the report on a connection from the factory and always hand it back")
+    void shouldRunOnAFactoryConnectionAndReleaseIt() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+        HashMap<String, Object> appContext = new HashMap<>();
+        Connection guarded = mock(Connection.class);
+
+        when(task.getAppContext()).thenReturn(appContext);
+        when(connectionFactory.guard(mockConnection)).thenReturn(guarded);
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        when(pdfRenderer.render(eq(reportEngine), anyString(), anyString()))
+                .thenReturn(Response.ok().type("application/pdf").build());
+
+        service.processRequest("sample", queryParams("PDF"));
+
+        InOrder inOrder = inOrder(connectionFactory, task);
+        inOrder.verify(connectionFactory).open();
+        inOrder.verify(task).run(anyString());
+        inOrder.verify(connectionFactory).release(mockConnection);
+
+        assertSame(guarded, appContext.get("OdaJDBCDriverPassInConnection"));
+        assertEquals(false, appContext.get("OdaJDBCDriverPassInConnectionCloseAfterUse"));
+    }
+
+    @Test
+    @DisplayName("Should hand the connection back when the report run fails")
+    void shouldReleaseTheConnectionWhenTheRunFails() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+
+        when(task.getAppContext()).thenReturn(new HashMap<>());
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        doThrow(new RuntimeException("boom")).when(task).run(anyString());
+
+        assertThrows(PlatformDataIntegrityException.class, () -> service.processRequest("sample", queryParams("PDF")));
+
+        verify(connectionFactory).release(mockConnection);
+    }
+
+    @Test
+    @DisplayName("Should apply the server-derived user context after the client parameters")
+    void shouldInjectServerContextAfterClientParameters() throws Exception {
+        IReportRunnable design = mock(IReportRunnable.class);
+        ReportDesignHandle designHandle = mock(ReportDesignHandle.class);
+        IRunTask task = mock(IRunTask.class);
+        HashMap<String, Object> appContext = new HashMap<>();
+
+        when(task.getAppContext()).thenReturn(appContext);
+        when(reportExecutionFactory.createExecutionRunnable(anyString(), any())).thenReturn(design);
+        when(design.getDesignHandle()).thenReturn(designHandle);
+        when(reportEngine.createRunTask(design)).thenReturn(task);
+        when(pdfRenderer.render(eq(reportEngine), anyString(), anyString()))
+                .thenReturn(Response.ok().type("application/pdf").build());
+
+        service.processRequest("sample", queryParams("PDF"));
+
+        InOrder inOrder = inOrder(parameterMapper, contextInjector, task);
+        inOrder.verify(parameterMapper).applyParameters(eq(task), any());
+        inOrder.verify(contextInjector).injectContextParameters(task);
+        inOrder.verify(task).run(anyString());
     }
 
     private BirtRenderer getRendererForType(String outputType) {

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/ReportSecurityServiceTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/ReportSecurityServiceTest.java
@@ -9,203 +9,69 @@ package org.apache.fineract.infrastructure.report.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
-import org.junit.jupiter.api.AfterEach;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReportSecurityService Tests")
 class ReportSecurityServiceTest {
 
+    private static final String REPORT_NAME = "Active_Loans_Details";
+
+    @Mock
+    private PlatformSecurityContext securityContext;
+
+    @Mock
+    private AppUser authenticatedUser;
+
+    @InjectMocks
     private ReportSecurityService reportSecurityService;
 
     @BeforeEach
     void setUp() {
-        reportSecurityService = new ReportSecurityService();
-        SecurityContextHolder.clearContext();
-    }
-
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
+        when(securityContext.authenticatedUser()).thenReturn(authenticatedUser);
     }
 
     @Test
-    @DisplayName("Should allow report execution when user has READ_REPORT permission")
-    void shouldAllowReportExecutionWhenUserHasReadReportPermission() {
+    @DisplayName("Should allow execution when the authenticated user is granted the report")
+    void shouldAllowExecutionWhenUserIsGrantedTheReport() {
+        when(authenticatedUser.hasNotPermissionForReport(REPORT_NAME)).thenReturn(false);
 
-        Authentication authentication = authenticatedUser(
-                "report-user", List.of(new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION)));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
+        assertThatCode(() -> reportSecurityService.checkReportExecutionPermission(REPORT_NAME))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    @DisplayName("Should reject report execution when user does not have READ_REPORT permission")
-    void shouldRejectReportExecutionWhenUserDoesNotHaveReadReportPermission() {
+    @DisplayName("Should reject execution when the authenticated user is not granted the report")
+    void shouldRejectExecutionWhenUserIsNotGrantedTheReport() {
+        when(authenticatedUser.hasNotPermissionForReport(REPORT_NAME)).thenReturn(true);
 
-        Authentication authentication = authenticatedUser(
-                "normal-user",
-                List.of(new SimpleGrantedAuthority("READ_CLIENT"), new SimpleGrantedAuthority("READ_LOAN")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
+        assertThatThrownBy(() -> reportSecurityService.checkReportExecutionPermission(REPORT_NAME))
+                .isInstanceOf(NoAuthorizationException.class)
+                .hasMessageContaining(REPORT_NAME);
     }
 
+    /**
+     * The grant is per report, not a blanket "may run reports": a user granted one report must not
+     * reach another by name.
+     */
     @Test
-    @DisplayName("Should reject report execution when authentication is null")
-    void shouldRejectReportExecutionWhenAuthenticationIsNull() {
+    @DisplayName("Should check the grant for the report being executed, not a generic one")
+    void shouldCheckTheGrantForTheRequestedReport() {
+        when(authenticatedUser.hasNotPermissionForReport("Other_Report")).thenReturn(true);
 
-        SecurityContextHolder.clearContext();
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("not authorized");
-    }
-
-    @Test
-    @DisplayName("Should reject report execution when user is not authenticated")
-    void shouldRejectReportExecutionWhenUserIsNotAuthenticated() {
-
-        Authentication authentication = mock(Authentication.class);
-
-        when(authentication.isAuthenticated()).thenReturn(false);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("not authorized");
-    }
-
-    @Test
-    @DisplayName("Should reject report execution when user has no authorities")
-    void shouldRejectReportExecutionWhenUserHasNoAuthorities() {
-
-        Authentication authentication = authenticatedUser("user-without-authorities", List.of());
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
-    }
-
-    @Test
-    @DisplayName("Should allow report execution when READ_REPORT exists among multiple permissions")
-    void shouldAllowReportExecutionWhenReadReportExistsAmongMultiplePermissions() {
-
-        Authentication authentication = authenticatedUser(
-                "report-user",
-                List.of(
-                        new SimpleGrantedAuthority("READ_CLIENT"),
-                        new SimpleGrantedAuthority("READ_LOAN"),
-                        new SimpleGrantedAuthority("READ_SAVINGS"),
-                        new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION),
-                        new SimpleGrantedAuthority("READ_ACCOUNT")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("Should reject similar but incorrect report permissions")
-    void shouldRejectSimilarButIncorrectReportPermissions() {
-
-        Authentication authentication = authenticatedUser(
-                "user",
-                List.of(
-                        new SimpleGrantedAuthority("READ_REPORTS"),
-                        new SimpleGrantedAuthority("REPORT_READ"),
-                        new SimpleGrantedAuthority("WRITE_REPORT")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
-    }
-
-    @Test
-    @DisplayName("Should require exact READ_REPORT permission")
-    void shouldRequireExactReadReportPermission() {
-
-        Authentication authentication = authenticatedUser(
-                "user",
-                List.of(
-                        new SimpleGrantedAuthority("read_report"),
-                        new SimpleGrantedAuthority("READ_REPORTS"),
-                        new SimpleGrantedAuthority("READ_REPORT ")));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class)
-                .hasMessageContaining("READ_REPORT");
-    }
-
-    @Test
-    @DisplayName("Should allow authenticated user with only READ_REPORT permission")
-    void shouldAllowAuthenticatedUserWithOnlyReadReportPermission() {
-
-        Authentication authentication = authenticatedUser(
-                "report-user", List.of(new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION)));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("Should not depend on username when checking READ_REPORT")
-    void shouldNotDependOnUsernameWhenCheckingReadReport() {
-
-        Authentication authentication = authenticatedUser(
-                "any-user", List.of(new SimpleGrantedAuthority(ReportSecurityService.READ_REPORT_PERMISSION)));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatCode(() -> reportSecurityService.checkReadReportPermission()).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("Should reject authentication with null authorities")
-    void shouldRejectAuthenticationWithNullAuthorities() {
-
-        Authentication authentication = mock(Authentication.class);
-
-        when(authentication.isAuthenticated()).thenReturn(true);
-
-        when(authentication.getPrincipal()).thenReturn("report-user");
-
-        when(authentication.getAuthorities()).thenReturn(null);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        assertThatThrownBy(() -> reportSecurityService.checkReadReportPermission())
-                .isInstanceOf(PlatformDataIntegrityException.class);
-    }
-
-    private Authentication authenticatedUser(String username, List<SimpleGrantedAuthority> authorities) {
-
-        return new UsernamePasswordAuthenticationToken(username, "password", authorities);
+        assertThatThrownBy(() -> reportSecurityService.checkReportExecutionPermission("Other_Report"))
+                .isInstanceOf(NoAuthorizationException.class)
+                .hasMessageContaining("Other_Report");
     }
 }


### PR DESCRIPTION
SQL embedded in a `.rptdesign` runs on the tenant's JDBC connection. Execution was already wrapped in a read-only `TransactionTemplate`, but that does not restrict the connection, so report SQL could write to the tenant database. This moves the restriction onto the connection and tightens the surrounding execution path.

Jira: [MX-403](https://mifosforge.jira.com/browse/MX-403)

Rebased onto `develop` at 6594e8a.

## Why the existing read-only transaction was not enough

Fineract's transaction manager is a `JpaTransactionManager`. It applies read-only to the persistence context and never calls `Connection.setReadOnly`, so the connection handed to BIRT is writable regardless. `BirtConnectionReadOnlyIntegrationTest.readOnlyTransactionDoesNotRestrictTheJdbcConnection` pins this against a real database: inside a read-only transaction the connection reports `isReadOnly() == false` and the `INSERT` goes through.

## Changes

**Connection.** Opening, restricting and releasing the report connection now lives in `BirtReadOnlyConnectionFactory`, so the tests drive the same code a report runs on instead of a copy of it. The connection is opened read-only with auto-commit off. Two details are deliberate:

- The transaction is opened with a `SELECT 1`. A database stops accepting `SET TRANSACTION READ WRITE` only once the transaction has taken its snapshot; without an initial statement, report SQL could switch the transaction to read-write and then write.
- On MySQL/MariaDB `Connection.setReadOnly` is a replica-routing hint and does not restrict writes, so the transaction is opened explicitly with `START TRANSACTION READ ONLY`. The check matches `:mysql` and `:mariadb` specifically, rather than "not PostgreSQL" — `jdbc:aws-wrapper:postgresql` and anything added later get their driver's own behaviour instead of a statement guessed on their behalf. Transaction-scoped rather than `SET SESSION`, because a session setting would survive the connection's return to the pool and leave later borrowers read-only.

If the restriction cannot be applied the connection is closed rather than handed on, since open-but-unrestricted is the one state a report must never see.

**Transaction-control guard.** The proxy BIRT receives wraps `createStatement` and `prepareStatement` — and the statements they return, which inherit the `execute(String)` overloads — and refuses `COMMIT`, `ROLLBACK`, `BEGIN`, `START TRANSACTION`, `SET TRANSACTION` and `SET SESSION`. `prepareCall` is refused outright. `commit()`, `rollback()`, `setReadOnly` and `setAutoCommit` on the connection are ignored.

Screening at the point the SQL is sent works even when a report script builds its query at run time, which is why inspecting the design was rejected. Matching is word-boundary, so `commit_date` and `beginning_balance` are not caught.

**Connection traversal.** A proxy in front of the connection is worth little if the objects it hands out are not, since JDBC lets a caller navigate from any of them back to the connection underneath. `710da02` closes that graph. The statements, their result sets and the database metadata are wrapped in turn, so every standard route resolves back to a guarded proxy rather than the physical connection:

| Route | Resolves to |
| --- | --- |
| `Statement.getConnection()` | guarded connection |
| `Connection.getMetaData().getConnection()` | guarded connection |
| `ResultSet.getStatement().getConnection()` | guarded statement, then guarded connection |
| `Statement.unwrap(...).getConnection()` | guarded statement, then guarded connection |
| `Connection.unwrap(...)` | the guarded proxy for an interface it implements; `SQLException` otherwise |

`isWrapperFor(...)` answers exactly the predicate `unwrap(...)` will satisfy, so a caller is never told to expect something it cannot get. `Statement.unwrap(...)` was not in the review comment; it is the same defect and is closed with the rest. Metadata result sets report `getStatement() == null`, which JDBC already defines for a result set no statement produced.

Each wrapper answers only navigation and identity methods — `getConnection`, `getStatement`, `unwrap`, `isWrapperFor`. Everything else delegates untouched, so an ordinary `ResultSet` operation, a column read included, behaves exactly as the driver's does.

This is still defence in depth, not the boundary. BIRT runs report script with unrestricted access to the JVM, which no JDBC wrapper can contain, so a `.rptdesign` remains a trusted, administrator-installed artefact. The read-only transaction catches ordinary writes and a `SELECT`-only principal is what actually holds.

**Connection pooling.** Reports running as the tenant's read-only principal go through a cached `HikariDataSource` per principal, keyed on JDBC URL and username, rather than a fresh `DriverManager` connection per report. Unpooled, the database's own `max_connections` was the only bound on concurrent reports, and exhausting it takes down all of Fineract rather than only reporting. Bounded by `mifos.birt.read-only-pool-max-size` (default 5) and `mifos.birt.read-only-connection-timeout-millis` (default 10s), with `minimumIdle=0`; pools are closed on shutdown.

**Parameters.** `R_userid` and `R_userhierarchy` are derived from the authenticated user. A client that supplies them gets a warning in the log and the value dropped. Deliberately not a rejection: the value was already unreachable — `BirtParameterMapper.applyParameters` skips these names and the context injector overwrites both afterwards — so failing the request would convert a no-op into an outage for stored `stretchy_report_param_map` entries carrying the Pentaho-era `R_userhierarchy`, which reach this through report mailing jobs where nobody would see the error. **No behaviour change for callers.**

**Authorization.** `ReportSecurityService` read authorities from `SecurityContextHolder` and accepted a generic `READ_REPORT`. It now resolves the user through `PlatformSecurityContext.authenticatedUser()` and checks `hasNotPermissionForReport(reportName)`, matching core Fineract. The check stays in `processRequest` because `ExecuteReportMailingJobsTasklet` reaches that method with no grant check of its own.

**Report loading.** `BirtReportLoader.buildReportPath` concatenated the request-supplied report name into a filesystem path. It now resolves symlinks with `toRealPath()` on both the base directory and the resolved path, confines the result to the reports directory, and the not-found message no longer carries the server path. After the MX-317 change the base directory comes from `c_external_service_properties` and is resolved per call, so containment is relative to whatever that column holds.

A strict filename pattern was considered instead and rejected. @raghavvag reported that `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$` fails 46 of the 68 designs in the wider catalogue, because report names carry spaces, dashes and brackets — "Active Loan Summary per Branch", "Aging Summary (Arrears in Months)". That catalogue is not in this repo so I have not re-run the check, but confinement gives the same containment without that risk.

**Read-only principal validation.** A tenant with `readonly_schema_username` set but the password blank or stored in plaintext used to surface as `error.msg.reporting.sql.error: Unknown SQL error`. It now fails with `error.msg.reporting.readonly.password.missing` or `error.msg.reporting.readonly.password.not.encrypted`, both naming `tenant_server_connections.readonly_schema_password` and saying it has to be encrypted like `schema_password`.

**App context.** `OdaJDBCDriverUser` and `OdaJDBCDriverPassword` are removed. BIRT's JDBC ODA driver returns as soon as it finds `OdaJDBCDriverPassInConnection`, so these were never read, and they placed the tenant's decrypted database password where report scripts could reach it.

**Documentation.** README section 5 told administrators to grant `READ_REPORT`, which this PR no longer accepts, and its example `READ_ACTIVE_LOANS_DETAILS` was uppercased where the code is `READ_` + `stretchy_report.report_name` verbatim. It now lists the four grants `hasNotPermissionForReport` accepts. A new section 4 documents provisioning the read-only principal — creating the role, both the `FINERACT_DEFAULT_TENANTDB_RO_*` route for a fresh tenant store and the encrypt-then-`UPDATE` route for an existing one, that `readonly_schema_password` has to be encrypted like `schema_password`, and the pool properties. Sections 5-10 renumbered; nothing cross-referenced the old numbers.

## Scope of protection

Writes issued through normal report SQL — INSERT, UPDATE, DELETE on PostgreSQL and MySQL/MariaDB, DDL on PostgreSQL — are refused by the database. The `COMMIT` then `START TRANSACTION READ WRITE` escape recorded in the previous revision of this PR is now refused by the guard before the driver sees it (`guardedConnectionRefusesTheEscape`); `reportCanEscapeByStartingItsOwnTransaction` stays, renamed, to record what the database alone still allows on an unguarded connection.

A malicious `.rptdesign` is not fully sandboxed. Closing the JDBC traversal paths does not change that: BIRT report script reaches the JVM directly, and MySQL/MariaDB permit DDL, which commits implicitly. `.rptdesign` files remain trusted, administrator-installed artefacts.

A database account restricted to `SELECT` does close all of it, and this PR supports one: when a tenant sets `readonly_schema_username`, reports connect as that principal, reusing the existing `tenant_server_connections.readonly_schema_*` columns rather than adding configuration. Provisioning it is deployment work — those columns are empty by default — but README section 4 now walks through it, which it did not before.

## Testing

`./mvnw clean verify` — 126 unit tests, 24 integration tests, spotless clean. Integration tests run against PostgreSQL and Fineract containers.

Added:

- `BirtReadOnlyConnectionFactoryTest` — restriction and its failure path, dialect detection including an aws-wrapper URL, pool reuse, statement screening, credential diagnostics.
- `BirtConnectionReadOnlyIntegrationTest` — connection behaviour against a real database, escape attempts guarded and unguarded, pool safety, leak-on-failure.
- `BirtReadOnlyPrincipalIntegrationTest` — renders a shipped report through a real `SELECT`-only role, then revokes that role's `SELECT` and confirms the same request fails. The revoke is what shows the report ran under that principal rather than the tenant's; a 200 alone would not. Tenant config is restored in `@AfterAll`.
- `ShippedReportDesignTest` — shipped designs stay parameterised, over the designs that carry a query, with a floor so that set cannot quietly empty.
- `guardedConnectionRefusesTheEscapeReachedThroughItsOwnObjects` — the traversal walked against a real database rather than a mock, on the existing Testcontainers PostgreSQL/Fineract infrastructure. It reads a row through the guarded connection, takes the connection back by result set, by metadata and by `unwrap`, asserts all three are the guarded object, and then confirms `COMMIT` and `START TRANSACTION READ WRITE` are still refused through what the walk returned, that the physical connection is still open, and that the table is unchanged either side.
- Unit tests for path and symlink confinement, parameter handling, the grant check, and for each traversal route above — metadata, result set, `unwrap` and `isWrapperFor` — each confirmed to fail with the fix reverted.

MySQL/MariaDB is not covered in CI; that needs an `org.testcontainers:mariadb` dependency, which this PR does not add. There is a unit test asserting `START TRANSACTION READ ONLY` is issued for a `jdbc:mariadb` URL and not for an unrecognised one, and the path was verified manually against MariaDB 11 with Connector/J 3.5.7. Can add the dependency in a follow-up.

## One commit that is not mine to make

`0893f15` fixes `xsi:schemaLocation` in `002-birt-external-service.xml` (added in MX-317): it reads `.../ns/dbchangelog-4.3.xsd`, missing the `/dbchangelog/` segment, so Liquibase cannot find the XSD bundled in `liquibase-core-4.33.0`, falls through to a remote lookup, and `secureParsing` refuses it. The plugin's migration then fails and Fineract's context does not start, which takes every integration test class with it.

Reproduced on a clean checkout of `develop` at 6594e8a with nothing else applied, so this is not introduced here. It is in this branch only because the suite cannot run without it. Happy to split it out — see the separate PR if one is open by the time you read this.


[MX-403]: https://mifosforge.jira.com/browse/MX-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now use dedicated read-only database connections with configurable pooling.
  * Report permissions are checked individually.
  * Server-managed identity parameters are protected from client overrides.

* **Bug Fixes**
  * Improved report path validation blocks traversal, absolute paths, and symlink escapes.
  * Report errors no longer expose server filesystem details.

* **Documentation**
  * Added configuration guidance for read-only report access and permissions.

* **Tests**
  * Added coverage for read-only enforcement, security, path handling, and report SQL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

