### PR TITLE
GAZ-306: Honour the dateFormat request parameter when parsing report date parameters

### DIFF
--- a/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
@@ -201,7 +201,7 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
         reportEnvironment.setLocale(locale);
       }
 
-      addParametersToReport(masterReport, reportParams);
+      addParametersToReport(masterReport, reportParams, queryParams.getFirst("dateFormat"));
 
       List<SubReport> subReports = getSubReports(masterReport);
       for (SubReport subReport : subReports) {
@@ -262,7 +262,9 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
   }
 
   private void addParametersToReport(
-      final MasterReport report, final Map<String, String> queryParams) {
+      final MasterReport report,
+      final Map<String, String> queryParams,
+      final String dateFormatParam) {
     final var currentUser = this.context.authenticatedUser();
     try {
       final var rptParamValues = report.getParameterValues();
@@ -309,7 +311,10 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
             logger.debug("ParamName: {}", paramName);
             logger.debug("ParamValue: {}", pValue.toString());
             String myDate = pValue.toString();
-            SimpleDateFormat sdf = new SimpleDateFormat("dd MMMM yyyy", Locale.ENGLISH);
+            final String datePattern =
+                StringUtils.isNotBlank(dateFormatParam) ? dateFormatParam : "dd MMMM yyyy";
+            SimpleDateFormat sdf = new SimpleDateFormat(datePattern, Locale.ENGLISH);
+            sdf.setLenient(false);
             Date date = sdf.parse(myDate);
             long millis = date.getTime();
             java.sql.Date mySQLDate = new java.sql.Date(millis);

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/PentahoReportsTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/PentahoReportsTest.java
@@ -69,6 +69,34 @@ public class PentahoReportsTest {
     Truth.assertThat(r.contentType()).isEqualTo(MediaType.get("application/pdf"));
   }
 
+  @Test
+  void reportHonoursRequestedDateFormat() {
+    ResponseBody r =
+        ok(
+            fineract("default")
+                .reportsRun
+                .runReportGetFile(
+                    "Expected Payments By Date - Formatted",
+                    Map.of(
+                        "tenantIdentifier",
+                        "default",
+                        "locale",
+                        "en",
+                        "dateFormat",
+                        "yyyy-MM-dd",
+                        "R_startDate",
+                        "2022-01-01",
+                        "R_endDate",
+                        "2023-01-02",
+                        "R_officeId",
+                        "1",
+                        "output-type",
+                        "PDF",
+                        "R_loanOfficerId",
+                        "-1")));
+    Truth.assertThat(r.contentType()).isEqualTo(MediaType.get("application/pdf"));
+  }
+
   /**
    * Verifies that a report is generated against the *requesting* tenant's database. The same report
    * is run for two different tenants; each must return that tenant's own data, so the (data) output


### PR DESCRIPTION
## Problem
When a Pentaho report with a date parameter is run from the web-app (or API), the
request sends the date value in the configured dateFormat, the web-app default is
`yyyy-MM-dd`, e.g. `R_fromDate=2020-01-01`. But `addParametersToReport` hardcoded
`new SimpleDateFormat("dd MMMM yyyy")` and ignored the `dateFormat` request parameter, 
so every date-driven report failed with `Pentaho failed: Unparseable date: "2020-01-01"`. 
This makes all date-parameter reports unusable from the web-app.

## Solution
Parse `java.sql.Date` parameters using the `dateFormat` request parameter when
present, falling back to the legacy `dd MMMM yyyy` when it isn't, so existing
callers that pass `dd MMMM yyyy` values without a `dateFormat` keep working.

## Testing
- Reproduced against the deployed plugin: `R_fromDate=2020-01-01&dateFormat=yyyy-MM-dd`
  → `Unparseable date: "2020-01-01"`.
- Verified the fix on Temurin 21: `SimpleDateFormat("yyyy-MM-dd").parse("2020-01-01")`
  parses; the `dd MMMM yyyy` fallback still parses `01 January 2020`; the old
  hardcoded path reproduces the bug.
- Added reportHonoursRequestedDateFormat to PentahoReportsTest: runs a date report with 
`dateFormat=yyyy-MM-dd`, which throws an unparseable date before this fix and passes after. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report date parameters now support an optional custom date format.
  * Existing date formatting remains available by default when no format is provided.

* **Bug Fixes**
  * Improved report generation for requests using ISO-formatted dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->