### PR TITLE
WEB-1200: Upload Eclipse BIRT report designs per tenant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<eclipselink.version>4.0.9</eclipselink.version>
 		<birt.version>4.24.0</birt.version>
 		<icu4j.version>78.3</icu4j.version>
+		<swagger.version>2.2.49</swagger.version>
                 <csv.emitter.version>1.0.11</csv.emitter.version>
 		<spotless.version>3.10.0</spotless.version>
 		<palantir-java-format.version>2.97.0</palantir-java-format.version>
@@ -62,6 +63,22 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
+		</dependency>
+		<!--
+		 Both are already on the Apache Fineract runtime classpath, which is what
+		 serves this plugin's JAX-RS resources and reads their annotations, so they
+		 are declared only to compile against and are not shipped by the plugin.
+		-->
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-multipart</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-annotations-jakarta</artifactId>
+			<version>${swagger.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/org/apache/fineract/infrastructure/report/api/BirtReportFilesApiResource.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/api/BirtReportFilesApiResource.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.report.data.BirtReportFileUploadData;
+import org.apache.fineract.infrastructure.report.service.BirtReportUploadService;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.springframework.stereotype.Component;
+
+/**
+ * Installs Eclipse BIRT® report designs into the authenticated tenant's reports directory.
+ *
+ * <p>Registered automatically: Apache Fineract®'s {@code JerseyConfig} registers every Spring bean
+ * annotated {@code @Path}, and this plugin is inside its component scan, so no wiring in the
+ * platform is needed.
+ *
+ * <p>The request carries a file and nothing else. There is deliberately no parameter for the
+ * destination, the tenant or any directory: those are the server's to decide.
+ */
+@Path("/v1/birt/reports")
+@Component
+@Tag(
+        name = "BIRT Report Files",
+        description = "Upload the Eclipse BIRT report designs (.rptdesign) a tenant's reports run from.")
+@RequiredArgsConstructor
+public class BirtReportFilesApiResource {
+
+    private final BirtReportUploadService uploadService;
+
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Upload a BIRT report design", description = """
+                    Stores a .rptdesign file in the reports directory of the tenant the request authenticated \
+                    as, replacing any design already stored under the same name.
+
+                    Body part:
+
+                    file : the .rptdesign to install
+
+                    Requires the CREATE_REPORT permission. Registering the report in the report catalogue is \
+                    a separate step; this resource only installs the design file.""")
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "OK",
+                content = @Content(schema = @Schema(implementation = BirtReportFileUploadData.class))),
+        @ApiResponse(responseCode = "400", description = "The file is not a valid BIRT report design"),
+        @ApiResponse(responseCode = "403", description = "The user does not have the CREATE_REPORT permission")
+    })
+    public BirtReportFileUploadData uploadReportDesign(
+            @FormDataParam("file") final InputStream inputStream,
+            @FormDataParam("file") final FormDataContentDisposition fileDetails) {
+
+        /*
+         * No Content-Length check here. It measures the whole request rather
+         * than the file, and a client sets it, so the size limit belongs where
+         * the bytes are actually counted, in the upload service.
+         */
+        return uploadService.upload(fileDetails == null ? null : fileDetails.getFileName(), inputStream);
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/data/BirtReportFileUploadData.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/data/BirtReportFileUploadData.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.data;
+
+/**
+ * What a successful report design upload tells the caller.
+ *
+ * <p>Deliberately says nothing about where the file landed: the destination is the server's to
+ * decide and the client has no use for it.
+ *
+ * @param fileName the name the design was stored under
+ * @param size its size in bytes
+ * @param overwritten whether a design of the same name was replaced
+ * @param reportName the design's name without the extension, which is the name a report in the
+ *     catalogue has to carry for this design to be used
+ */
+public record BirtReportFileUploadData(String fileName, long size, boolean overwritten, String reportName) {}

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportLoader.java
@@ -7,23 +7,19 @@
 package org.apache.fineract.infrastructure.report.service;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
 import org.eclipse.birt.report.engine.api.IReportEngine;
 import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
@@ -35,19 +31,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class BirtReportLoader {
     private final IReportEngine reportEngine;
-    private final BirtPluginProperties birtProperties;
+    private final BirtReportsDirectory reportsDirectory;
     private final ReportErrorHandler reportErrorHandler;
     private final ConcurrentMap<String, Long> reportModificationTimes = new ConcurrentHashMap<>();
     private final CacheManager cacheManager;
-    private final JdbcTemplate jdbcTemplate;
 
-    private static final String DEFAULT_REPORTS_DIR = System.getProperty("user.home")
-            + File.separator
-            + ".mifosx"
-            + File.separator
-            + "birtReports"
-            + File.separator;
-    private static final String CACHE_KEY = "#reportName + '_' + (#locale != null ? #locale.getLanguage() : 'en')";
+    /**
+     * The design a name resolves to depends on the tenant, so the tenant belongs in the key. Without
+     * it one tenant's compiled design is served to the next tenant that asks for the same name.
+     */
+    private static final String CACHE_KEY = "#root.target.buildCacheKey(#reportName, #locale)";
 
     /**
      * Loads a BIRT report design with caching enabled.
@@ -59,7 +52,15 @@ public class BirtReportLoader {
     @Cacheable(value = "birtReports", key = CACHE_KEY, sync = true)
     public IReportRunnable loadReport(String reportName, java.util.Locale locale) {
 
-        String reportPath = buildReportPath(reportName, locale);
+        Optional<Path> resolved = resolveReportFile(reportName, locale);
+
+        if (resolved.isEmpty()) {
+            log.error("Report design file not found for report: {}", reportName);
+            throw reportErrorHandler.reportError(
+                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
+        }
+
+        String reportPath = resolved.get().toString();
 
         log.info(
                 "Cache miss for BIRT report: {} (locale: {}). Loading template from disk: {}",
@@ -68,12 +69,6 @@ public class BirtReportLoader {
                 reportPath);
 
         File reportFile = new File(reportPath);
-
-        if (!reportFile.exists()) {
-            log.error("Report design file not found: {}", reportPath);
-            throw reportErrorHandler.reportError(
-                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
-        }
 
         if (!reportFile.canRead()) {
             log.error("Report file exists but is not readable: {}", reportPath);
@@ -94,41 +89,70 @@ public class BirtReportLoader {
     }
 
     public void validateTemplateFreshness(String reportName, java.util.Locale locale) {
-        String reportPath = buildReportPath(reportName, locale);
-        File reportFile = new File(reportPath);
 
-        if (!reportFile.exists()) {
+        Optional<Path> resolved = resolveReportFile(reportName, locale);
+
+        if (resolved.isEmpty()) {
+
             evictCacheEntry(reportName, locale);
+
             log.info("Report template no longer exists on disk. Evicted cached version: {}", reportName);
+
             return;
         }
 
         String cacheKey = buildCacheKey(reportName, locale);
-        long currentLastModified = reportFile.lastModified();
+
+        long currentLastModified = resolved.get().toFile().lastModified();
+
         Long cachedLastModified = reportModificationTimes.get(cacheKey);
 
         if (cachedLastModified != null && !cachedLastModified.equals(currentLastModified)) {
+
             log.info(
                     "Detected modification for report template: {} (locale: {}). Evicting cached version.",
                     reportName,
                     locale != null ? locale.getLanguage() : "en");
+
             evictCacheEntry(reportName, locale);
         }
 
         reportModificationTimes.put(cacheKey, currentLastModified);
     }
 
-    private String buildCacheKey(String reportName, java.util.Locale locale) {
-        return reportName + "_" + (locale != null ? locale.getLanguage() : "en");
+    /**
+     * Public because the {@code @Cacheable} and {@code @CacheEvict} keys call it through
+     * {@code #root.target}, which keeps one definition of the key instead of a SpEL copy that can
+     * drift away from the Java one.
+     */
+    public String buildCacheKey(String reportName, java.util.Locale locale) {
+        return segment(reportsDirectory.tenantIdentifier())
+                + segment(reportName)
+                + segment(locale != null ? locale.getLanguage() : "en");
+    }
+
+    /**
+     * Joining the parts with a separator is not enough, because a tenant identifier and a report
+     * name may both contain it: tenant {@code a} with report {@code b_c} would key the same entry as
+     * tenant {@code a_b} with report {@code c}. Prefixing each part with its length keeps the key
+     * unambiguous whatever the parts contain.
+     */
+    private String segment(String value) {
+        return value.length() + "_" + value;
     }
 
     private void evictCacheEntry(String reportName, java.util.Locale locale) {
+
         String cacheKey = buildCacheKey(reportName, locale);
+
         Cache cache = cacheManager.getCache("birtReports");
+
         if (cache != null) {
             cache.evict(cacheKey);
         }
+
         reportModificationTimes.remove(cacheKey);
+
         log.info(
                 "Evicted cached BIRT report template: {} (locale: {})",
                 reportName,
@@ -136,80 +160,27 @@ public class BirtReportLoader {
     }
 
     /**
-     * Builds the full path to the .rptdesign file, supporting locale-specific variants.
+     * Resolves the .rptdesign file for a report, supporting locale-specific variants.
      *
-     * <p>The report name reaches this method straight from the request path, so the resolved file has
-     * to be confined to the reports directory: anything that escapes it is rejected as not found.
+     * <p>The report name arrives straight from the request path, so resolution is delegated to
+     * {@link BirtReportsDirectory}, which looks in the tenant's own directory before the shared one
+     * and confines the result to whichever it found: a name that escapes the reports tree resolves
+     * to nothing and reaches the caller as a report that does not exist.
      */
-    private String buildReportPath(String reportName, java.util.Locale locale) {
-        final String languageTag = (locale != null && !"en".equalsIgnoreCase(locale.getLanguage()))
+    private Optional<Path> resolveReportFile(String reportName, java.util.Locale locale) {
+        String languageTag = (locale != null && !"en".equalsIgnoreCase(locale.getLanguage()))
                 ? "_" + locale.getLanguage().toLowerCase()
                 : "";
 
         try {
-            /*
-             * The base directory is resolved here rather than before the try
-             * because it comes from c_external_service_properties, so a value
-             * an administrator stored can be no more a path than the report
-             * name can. Both reach the caller as the same not-found.
-             */
-            final Path baseDir = realPath(
-                    Paths.get(getBaseReportsDirectory()).toAbsolutePath().normalize());
-            final Path reportPath = realPath(
-                    baseDir.resolve(reportName + languageTag + ".rptdesign").normalize());
-            if (reportPath.startsWith(baseDir)) {
-                return reportPath.toString();
-            }
+            return reportsDirectory.resolveExisting(reportName + languageTag + ".rptdesign");
         } catch (InvalidPathException e) {
             log.error(
                     "Rejected BIRT report [{}]: neither it nor the configured reports directory is a path",
                     reportName,
                     e);
-            throw reportErrorHandler.reportError(
-                    "error.msg.reporting.report.not.found", "Report file not found: " + reportName, e);
+            return Optional.empty();
         }
-
-        log.error("Rejected BIRT report name resolving outside the reports directory: {}", reportName);
-        throw reportErrorHandler.reportError(
-                "error.msg.reporting.report.not.found", "Report file not found: " + reportName);
-    }
-
-    /**
-     * Resolves symlinks so the containment check cannot be walked around by a link inside the reports
-     * directory. A path that does not exist yet has nothing to resolve, and stays as it is: the
-     * caller reports it as not found either way.
-     */
-    private Path realPath(Path path) {
-        try {
-            return path.toRealPath();
-        } catch (IOException e) {
-            return path;
-        }
-    }
-
-    /** Returns the base directory for BIRT reports. Priority: Database -> Properties -> Default */
-    private String getBaseReportsDirectory() {
-        // 1. Primary: Fetch from c_external_service_properties (Hot-swapping architecture)
-        try {
-            String sql = "SELECT p.value FROM c_external_service_properties p "
-                    + "JOIN c_external_service s ON p.external_service_id = s.id "
-                    + "WHERE s.name = 'BIRT' AND p.name = 'reports_dir'";
-            String dbPath = jdbcTemplate.queryForObject(sql, String.class);
-            if (StringUtils.isNotBlank(dbPath)) {
-                log.info("BIRT reports directory loaded dynamically from database: {}", dbPath);
-                return dbPath; // CRITICAL: This actually hands the path back to the engine!
-            }
-        } catch (Exception e) {
-            log.debug("BIRT external service configuration not found in DB. Falling back to application properties.");
-        }
-
-        // 2. Secondary: Fallback to application.properties / ENV vars
-        if (StringUtils.isNotBlank(birtProperties.getReportsPath())) {
-            return birtProperties.getReportsPath();
-        }
-
-        // 3. Absolute Fallback
-        return DEFAULT_REPORTS_DIR;
     }
 
     /**
@@ -220,7 +191,9 @@ public class BirtReportLoader {
      */
     @CacheEvict(value = "birtReports", key = CACHE_KEY)
     public void evictFromCache(String reportName, java.util.Locale locale) {
+
         reportModificationTimes.remove(buildCacheKey(reportName, locale));
+
         log.info(
                 "Evicting BIRT report template from cache: {} (locale: {})",
                 reportName,

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportUploadService.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportUploadService.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Locale;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.exception.PlatformInternalServerException;
+import org.apache.fineract.infrastructure.report.data.BirtReportFileUploadData;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Element;
+
+/**
+ * Stores an uploaded Eclipse BIRT® report design in the authenticated tenant's reports directory.
+ *
+ * <p>The caller supplies a file and nothing else. Where the file goes is decided here, from the
+ * tenant Apache Fineract® authenticated the request as, so no request can reach another tenant's
+ * directory or anywhere outside the reports tree.
+ *
+ * <p>Nothing evicts the design cache: {@code BirtReportExecutionFactory} already calls
+ * {@link BirtReportLoader#validateTemplateFreshness} before every run, which notices the changed
+ * modification time and evicts the stale entry itself.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BirtReportUploadService {
+
+    /** The extension Eclipse BIRT® report designs carry, and the only one accepted. */
+    public static final String DESIGN_EXTENSION = ".rptdesign";
+
+    /**
+     * Matches the limit Apache Fineract® applies to its own document uploads
+     * ({@code ContentRepository.MAX_FILE_UPLOAD_SIZE_IN_MB}). A report design is XML and normally
+     * well under a megabyte; the limit is here to stop a client streaming without end, not to size
+     * real designs.
+     */
+    public static final long MAX_DESIGN_SIZE_BYTES = 5L * 1024 * 1024;
+
+    private static final String PARAMETER = "file";
+    private static final String RESOURCE = "birtreportfile";
+    private static final String DESIGN_ROOT_ELEMENT = "report";
+    private static final String DESIGN_NAMESPACE = "http://www.eclipse.org/birt/2005/design";
+
+    private final BirtReportsDirectory reportsDirectory;
+    private final ReportSecurityService reportSecurityService;
+
+    public BirtReportFileUploadData upload(final String submittedFileName, final InputStream content) {
+
+        reportSecurityService.checkCreateReportPermission();
+
+        final String fileName = validatedFileName(submittedFileName);
+        final byte[] design = readBounded(content, fileName);
+        validateReportDesign(design, fileName);
+
+        final Path target = destination(fileName);
+        final boolean overwritten = Files.isRegularFile(target);
+        write(design, target, fileName);
+
+        log.info(
+                "BIRT report design uploaded | tenant={} | file={} | bytes={} | overwrote={}",
+                reportsDirectory.tenantIdentifier(),
+                fileName,
+                design.length,
+                overwritten);
+
+        return new BirtReportFileUploadData(fileName, design.length, overwritten, reportNameOf(fileName));
+    }
+
+    /**
+     * A multipart part carries whatever name the client chose, so the name is checked rather than
+     * repaired. {@link org.apache.fineract.infrastructure.report.util.FilenameUtils#sanitizeFilename}
+     * is deliberately not used here: it rewrites every character outside {@code [A-Za-z0-9_.-]},
+     * which would silently turn {@code Active Loans.rptdesign} into a design no report of that name
+     * can ever load.
+     */
+    private String validatedFileName(final String submittedFileName) {
+        if (StringUtils.isBlank(submittedFileName)) {
+            throw validationError("filename.missing", "No report file name was supplied.");
+        }
+
+        final String fileName = submittedFileName.trim();
+
+        if (StringUtils.containsAny(fileName, '/', '\\', '\0') || fileName.contains("..")) {
+            log.warn("Rejected BIRT report design upload with a path in its name: {}", fileName);
+            throw validationError("filename.invalid", "A report file name may not contain a path: " + fileName);
+        }
+
+        if (!fileName.toLowerCase(Locale.ROOT).endsWith(DESIGN_EXTENSION)
+                || fileName.length() == DESIGN_EXTENSION.length()) {
+            throw validationError(
+                    "extension.invalid",
+                    "Only Eclipse BIRT report designs (" + DESIGN_EXTENSION + ") may be uploaded, but got: "
+                            + fileName);
+        }
+
+        return fileName;
+    }
+
+    /**
+     * Reads the whole design, refusing anything over the limit. The limit is enforced on what is
+     * actually read rather than on a {@code Content-Length} the client controls, so an oversized
+     * body cannot be smuggled past it by understating its size.
+     */
+    private byte[] readBounded(final InputStream content, final String fileName) {
+        if (content == null) {
+            throw validationError("file.missing", "No report file was supplied.");
+        }
+        try (BufferedInputStream in = new BufferedInputStream(content)) {
+            final byte[] design = in.readNBytes((int) MAX_DESIGN_SIZE_BYTES + 1);
+
+            if (design.length == 0) {
+                throw validationError("file.empty", "The uploaded report file is empty: " + fileName);
+            }
+            if (design.length > MAX_DESIGN_SIZE_BYTES) {
+                throw validationError(
+                        "file.too.large",
+                        "The uploaded report file exceeds " + MAX_DESIGN_SIZE_BYTES + " bytes: " + fileName);
+            }
+            return design;
+        } catch (IOException e) {
+            throw new PlatformInternalServerException(
+                    "error.msg.reporting.upload.read.failed",
+                    "Failed to read the uploaded report file: " + fileName,
+                    fileName);
+        }
+    }
+
+    /**
+     * Confirms the bytes are a report design rather than something renamed to look like one. The
+     * parser is the hardened one the plugin already uses for report XML — no doctype, no external
+     * entities — because this content is untrusted until it has been read.
+     *
+     * <p>This is a shape check, not a schema check: it stops a PDF, an archive or an unrelated
+     * document from being installed as a report, and leaves the rest to Eclipse BIRT® itself.
+     */
+    private void validateReportDesign(final byte[] design, final String fileName) {
+        final Element root;
+        try {
+            root = hardenedDocumentBuilderFactory()
+                    .newDocumentBuilder()
+                    .parse(new ByteArrayInputStream(design))
+                    .getDocumentElement();
+        } catch (Exception e) {
+            log.debug("Uploaded report file {} could not be parsed as XML", fileName, e);
+            throw validationError(
+                    "design.invalid", "The uploaded file is not a readable Eclipse BIRT report design: " + fileName);
+        }
+
+        final boolean isReportElement = root != null && DESIGN_ROOT_ELEMENT.equals(root.getLocalName());
+        /*
+         * A design written by the BIRT designer declares the design namespace,
+         * but one hand-written without it still opens, so an absent namespace
+         * is accepted and a wrong one is not.
+         */
+        final boolean namespaceIsBirt =
+                root != null && (root.getNamespaceURI() == null || DESIGN_NAMESPACE.equals(root.getNamespaceURI()));
+
+        if (!isReportElement || !namespaceIsBirt) {
+            throw validationError(
+                    "design.invalid", "The uploaded file is not an Eclipse BIRT report design: " + fileName);
+        }
+    }
+
+    private DocumentBuilderFactory hardenedDocumentBuilderFactory() throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (IllegalArgumentException e) {
+            log.debug("JAXP properties ACCESS_EXTERNAL_DTD/SCHEMA not supported by the XML parser. Ignoring.");
+        }
+
+        return factory;
+    }
+
+    private Path destination(final String fileName) {
+        try {
+            return reportsDirectory.resolveForWrite(fileName);
+        } catch (IllegalArgumentException e) {
+            log.warn("Rejected BIRT report design upload resolving outside the tenant directory: {}", fileName);
+            throw validationError("filename.invalid", "A report file name may not contain a path: " + fileName);
+        } catch (IOException e) {
+            log.error("Failed to open the reports directory for {}", fileName, e);
+            throw new PlatformInternalServerException(
+                    "error.msg.reporting.upload.storage.failed",
+                    "Failed to open the reports directory for: " + fileName,
+                    fileName);
+        }
+    }
+
+    /**
+     * Writes beside the destination and moves into place, so an upload that fails part way through
+     * cannot leave a half-written design where a working one used to be. The move replaces an
+     * existing design of the same name, which is how overwriting works.
+     *
+     * <p>{@code ATOMIC_MOVE} makes {@code REPLACE_EXISTING} implementation-defined, so a provider is
+     * free to refuse an existing target instead of replacing it. Overwriting is part of the contract
+     * here, so that refusal falls back to the plain replacing move rather than reaching the caller
+     * as a storage failure.
+     */
+    private void write(final byte[] design, final Path target, final String fileName) {
+        Path staged = null;
+        try {
+            staged = Files.createTempFile(target.getParent(), ".upload-", DESIGN_EXTENSION);
+            Files.write(staged, design);
+            try {
+                Files.move(staged, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException e) {
+                log.debug("Atomic replace of {} was refused. Falling back to a non-atomic replace.", fileName, e);
+                Files.move(staged, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            staged = null;
+        } catch (IOException e) {
+            log.error("Failed to store the report design {}", fileName, e);
+            throw new PlatformInternalServerException(
+                    "error.msg.reporting.upload.storage.failed",
+                    "Failed to store the report design: " + fileName,
+                    fileName);
+        } finally {
+            deleteQuietly(staged);
+        }
+    }
+
+    private void deleteQuietly(final Path staged) {
+        if (staged == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(staged);
+        } catch (IOException e) {
+            log.warn("Failed to remove the staged report design {}", staged, e);
+        }
+    }
+
+    private String reportNameOf(final String fileName) {
+        return fileName.substring(0, fileName.length() - DESIGN_EXTENSION.length());
+    }
+
+    private PlatformApiDataValidationException validationError(final String code, final String message) {
+        final ApiParameterError error =
+                ApiParameterError.parameterError("validation.msg." + RESOURCE + "." + code, message, PARAMETER);
+        return new PlatformApiDataValidationException(
+                "validation.msg.validation.errors.exist", "Validation errors exist.", List.of(error));
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportsDirectory.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/BirtReportsDirectory.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Single source of truth for where a tenant's BIRT report designs live, shared by the loader that
+ * reads them and the upload service that writes them so the two cannot drift apart.
+ *
+ * <p>The base directory is resolved as it always was, from the {@code BIRT} external service's
+ * {@code reports_dir} property, then {@code mifos.birt.reports-path} / {@code
+ * MIFOS_BIRT_REPORTS_PATH}, falling back to {@code ~/.mifosx/birtReports/}. All three are process
+ * wide, so <strong>the base directory is one directory shared by every tenant</strong>.
+ *
+ * <p>An upload therefore lands in a subdirectory named for the authenticated tenant, and a read
+ * looks there before falling back to the base directory so the designs an administrator installed
+ * by hand keep resolving. That subdirectory is what keeps one tenant's uploads out of another's
+ * reach; without it there would be nothing separating them.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BirtReportsDirectory {
+
+    private static final String DEFAULT_REPORTS_DIR =
+            System.getProperty("user.home") + File.separator + ".mifosx" + File.separator + "birtReports";
+
+    private final BirtPluginProperties birtProperties;
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * The tenant the current request authenticated as. Taken from the thread context Apache
+     * Fineract® bound while authenticating, never from anything the caller sent.
+     */
+    public String tenantIdentifier() {
+        final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
+        if (tenant == null || StringUtils.isBlank(tenant.getTenantIdentifier())) {
+            throw new IllegalStateException("No Apache Fineract tenant is bound to the current thread");
+        }
+        return tenant.getTenantIdentifier();
+    }
+
+    /** The configured base reports directory, shared by every tenant. */
+    public Path base() {
+        return Paths.get(configuredBaseDirectory()).toAbsolutePath().normalize();
+    }
+
+    /** The authenticated tenant's own reports directory, below {@link #base()}. */
+    public Path tenantDirectory() {
+        return base().resolve(tenantIdentifier()).normalize();
+    }
+
+    /**
+     * Resolves a report file for reading: the tenant's own directory first, then the shared base
+     * directory. Empty when the file is absent, or when the name does not resolve to a file directly
+     * in one of them.
+     */
+    public Optional<Path> resolveExisting(final String fileName) {
+        for (Path directory : List.of(tenantDirectory(), base())) {
+            final Optional<Path> candidate = resolveWithin(directory, fileName);
+            if (candidate.isPresent() && Files.isRegularFile(candidate.get())) {
+                return candidate;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Resolves a report file for writing. A write only ever goes to the authenticated tenant's own
+     * directory, which is created if it does not exist yet.
+     *
+     * <p>The name has to land directly in that directory. Containment alone would also admit {@code
+     * nested/report.rptdesign}, which stays inside the tenant's tree but is not somewhere the loader
+     * would ever look, so it is refused here rather than left to each caller.
+     *
+     * @throws IllegalArgumentException when the name does not resolve to a file directly in that
+     *     directory
+     * @throws IOException when the directory cannot be created
+     */
+    public Path resolveForWrite(final String fileName) throws IOException {
+        final Path directory = tenantDirectory();
+        Files.createDirectories(directory);
+
+        return resolveWithin(directory, fileName)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Report file name does not resolve to a file in the tenant reports directory: " + fileName));
+    }
+
+    /**
+     * Resolves {@code fileName} to a file directly in {@code directory}. Symlinks are resolved first
+     * so a link planted inside the directory cannot be used to step out of it; a path that does not
+     * exist yet has nothing to resolve and is compared as it stands.
+     *
+     * <p>Containment on its own is not enough. It would also admit {@code nested/report.rptdesign},
+     * and below the shared base directory the nested name is another tenant's own directory: {@code
+     * tenantA/Private} read as one report name would hand tenant A's design to whoever asked. So the
+     * name has to land directly in the directory, not merely somewhere under it.
+     */
+    private Optional<Path> resolveWithin(final Path directory, final String fileName) {
+        final Path root = realPath(directory);
+        final Path target = realPath(root.resolve(fileName).normalize());
+        return root.equals(target.getParent()) ? Optional.of(target) : Optional.empty();
+    }
+
+    private Path realPath(final Path path) {
+        try {
+            return path.toRealPath();
+        } catch (IOException e) {
+            return path;
+        }
+    }
+
+    /**
+     * Priority: the {@code BIRT} external service's {@code reports_dir} property, so the directory
+     * can be swapped without a restart, then the configured path, then the default directory.
+     */
+    private String configuredBaseDirectory() {
+        try {
+            final String sql = "SELECT p.value FROM c_external_service_properties p "
+                    + "JOIN c_external_service s ON p.external_service_id = s.id "
+                    + "WHERE s.name = 'BIRT' AND p.name = 'reports_dir'";
+            final String dbPath = jdbcTemplate.queryForObject(sql, String.class);
+            if (StringUtils.isNotBlank(dbPath)) {
+                log.debug("BIRT reports directory loaded from the external service configuration: {}", dbPath);
+                return dbPath;
+            }
+        } catch (Exception e) {
+            log.debug("BIRT external service configuration not found. Falling back to application properties.");
+        }
+
+        if (StringUtils.isNotBlank(birtProperties.getReportsPath())) {
+            return birtProperties.getReportsPath();
+        }
+        return DEFAULT_REPORTS_DIR;
+    }
+}

--- a/src/main/java/org/apache/fineract/infrastructure/report/service/ReportSecurityService.java
+++ b/src/main/java/org/apache/fineract/infrastructure/report/service/ReportSecurityService.java
@@ -20,6 +20,14 @@ public class ReportSecurityService {
     private final PlatformSecurityContext securityContext;
 
     /**
+     * Apache Fineract permission required to install a report design. It is the same grant that
+     * authorises adding a report to the catalogue, so no new permission is introduced: a user who
+     * may register a report already decides what a report is, and one who may not has no route to
+     * the reports directory either.
+     */
+    public static final String CREATE_REPORT_PERMISSION = "CREATE_REPORT";
+
+    /**
      * Verifies that the authenticated Apache Fineract user is granted the report that is about to be
      * executed.
      *
@@ -40,5 +48,24 @@ public class ReportSecurityService {
         if (currentUser.hasNotPermissionForReport(reportName)) {
             throw new NoAuthorizationException("Not authorised to run report: " + reportName);
         }
+    }
+
+    /**
+     * Verifies that the currently authenticated Apache Fineract user may install a report design.
+     *
+     * <p>Hiding the button in the web app is not a check; this is. It runs before the uploaded file
+     * is read, validated or written.
+     *
+     * <p>The user comes from {@link PlatformSecurityContext} and the grant is checked by Apache
+     * Fineract's own {@link AppUser#validateHasPermissionTo(String)}, so this resolves roles the way
+     * the rest of the platform does. That also settles the blanket grants correctly: {@code
+     * ALL_FUNCTIONS} passes, while {@code ALL_FUNCTIONS_READ} does not, because installing a design
+     * is a write.
+     *
+     * @throws NoAuthorizationException when the user does not have {@code CREATE_REPORT}
+     */
+    public void checkCreateReportPermission() {
+
+        securityContext.authenticatedUser().validateHasPermissionTo(CREATE_REPORT_PERMISSION);
     }
 }

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtIntegrationTestBase.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtIntegrationTestBase.java
@@ -7,7 +7,13 @@
 package org.apache.fineract.infrastructure.report.integration;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
+import java.util.Comparator;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
@@ -27,12 +33,30 @@ public abstract class BirtIntegrationTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(BirtIntegrationTestBase.class);
 
+    /** The tenant Apache Fineract provisions for itself from the environment. */
+    protected static final String DEFAULT_TENANT = "default";
+
+    /**
+     * A second tenant, registered below, so tests can prove that one tenant cannot reach another's
+     * report designs. A single tenant cannot demonstrate isolation of anything.
+     */
+    protected static final String SECOND_TENANT = "second";
+
+    protected static final String DEFAULT_TENANT_DB = "fineract_default";
+    protected static final String SECOND_TENANT_DB = "fineract_second";
+
+    /** Where the reports directory bound into the container lives on the host. */
+    protected static final Path REPORTS_DIR =
+            Paths.get("target", "it-birt-reports").toAbsolutePath();
+
+    private static final String REPORTS_DIR_IN_CONTAINER = "/app/birt/reports";
+
     protected static final Network NETWORK = Network.newNetwork();
 
     protected static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
             .withNetwork(NETWORK)
             .withNetworkAliases("db")
-            .withDatabaseName("fineract_default")
+            .withDatabaseName(DEFAULT_TENANT_DB)
             .withUsername("postgres")
             .withPassword("postgres");
 
@@ -41,17 +65,86 @@ public abstract class BirtIntegrationTestBase {
     static {
         POSTGRES.start();
 
-        try {
-            POSTGRES.execInContainer("psql", "-U", "postgres", "-c", "CREATE DATABASE fineract_tenants;");
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to create fineract_tenants database", e);
-        }
+        psql("postgres", "CREATE DATABASE fineract_tenants;");
 
+        seedReportsDirectory();
+
+        /*
+         * Apache Fineract creates the tenant store and the default tenant on its
+         * first boot, so a second tenant cannot be registered before that has
+         * happened. It is registered in between the two boots below, and the
+         * restart is what makes Apache Fineract read it: tenant details are
+         * resolved once at startup, so a tenant inserted into a running server is
+         * not picked up.
+         */
+        FINERACT = buildFineract();
+        FINERACT.start();
+
+        registerSecondTenant();
+
+        FINERACT.stop();
+        FINERACT = buildFineract();
+        FINERACT.start();
+    }
+
+    /**
+     * Copies the report designs shipped in the repository into a writable directory under
+     * {@code target/}.
+     *
+     * <p>The directory is bound read-write because installing a design is the feature under test.
+     * Copying rather than binding {@code birt/reports} directly keeps an uploading test from writing
+     * into the working tree, and leaves the shipped designs where the loader's fallback expects them
+     * so the reports the other tests run are still found.
+     */
+    private static void seedReportsDirectory() {
+        try {
+            deleteRecursively(REPORTS_DIR);
+            Files.createDirectories(REPORTS_DIR);
+
+            Path shipped = Paths.get("birt", "reports").toAbsolutePath();
+            try (Stream<Path> designs = Files.list(shipped)) {
+                designs.filter(Files::isRegularFile).forEach(design -> {
+                    try {
+                        Files.copy(
+                                design,
+                                REPORTS_DIR.resolve(design.getFileName().toString()),
+                                StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        throw new IllegalStateException("Unable to stage report design " + design, e);
+                    }
+                });
+            }
+
+            // The container runs as its own user and has to be able to create the tenant directory.
+            REPORTS_DIR.toFile().setWritable(true, false);
+            REPORTS_DIR.toFile().setReadable(true, false);
+            REPORTS_DIR.toFile().setExecutable(true, false);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to stage the BIRT reports directory", e);
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Unable to clean " + path, e);
+                }
+            });
+        }
+    }
+
+    private static GenericContainer<?> buildFineract() {
         String image = System.getProperty("fineract.it.image", "apache/fineract:develop");
 
         DockerImageName imageName = DockerImageName.parse(image).asCompatibleSubstituteFor("apache/fineract");
 
-        FINERACT = new GenericContainer<>(imageName)
+        GenericContainer<?> fineract = new GenericContainer<>(imageName)
                 .withNetwork(NETWORK)
                 .withExposedPorts(8443)
                 .withEnv("FINERACT_HIKARI_JDBC_URL", "jdbc:postgresql://db:5432/fineract_tenants")
@@ -68,23 +161,20 @@ public abstract class BirtIntegrationTestBase {
                 .withEnv("FINERACT_SERVER_SSL_ENABLED", "true")
                 .withEnv("FINERACT_SERVER_PORT", "8443")
                 // 1. Tell the plugin where to look for reports
-                .withEnv("MIFOS_BIRT_REPORTS_PATH", "/app/birt/reports");
+                .withEnv("MIFOS_BIRT_REPORTS_PATH", REPORTS_DIR_IN_CONTAINER);
 
         // 2. Safely copy the ENTIRE directory of runtime dependencies gathered by Maven
-        FINERACT.withCopyFileToContainer(MountableFile.forHostPath("target/test-runtime/libs"), "/app/birt/libs");
+        fineract.withCopyFileToContainer(MountableFile.forHostPath("target/test-runtime/libs"), "/app/birt/libs");
 
         // 3. Copy the plugin jar cleanly into the root of /app/birt with a safe fallback path
         String pluginJarPath = System.getProperty("birt.plugin.jar", "target/birt-plugin-1.15.0-SNAPSHOT.jar");
-        FINERACT.withCopyFileToContainer(MountableFile.forHostPath(pluginJarPath), "/app/birt/birt-plugin.jar");
+        fineract.withCopyFileToContainer(MountableFile.forHostPath(pluginJarPath), "/app/birt/birt-plugin.jar");
 
-        // 4. Mount the entire directory of migrated report design files into the container
-        FINERACT.withFileSystemBind(
-                java.nio.file.Paths.get("birt/reports").toAbsolutePath().toString(),
-                "/app/birt/reports",
-                BindMode.READ_ONLY);
+        // 4. Mount the staged reports directory, writable so designs can be installed into it
+        fineract.withFileSystemBind(REPORTS_DIR.toString(), REPORTS_DIR_IN_CONTAINER, BindMode.READ_WRITE);
 
         // 5. Emulate Jib's classpath modification scheme to mount dependencies cleanly
-        FINERACT.withCreateContainerCmdModifier(cmd -> {
+        fineract.withCreateContainerCmdModifier(cmd -> {
             cmd.withEntrypoint(
                     "sh",
                     "-c",
@@ -98,13 +188,74 @@ public abstract class BirtIntegrationTestBase {
             cmd.withCmd();
         });
 
-        FINERACT.withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("fineract"))
+        fineract.withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("fineract"))
                 .waitingFor(Wait.forHttps("/fineract-provider/actuator/health")
                         .allowInsecure()
                         .forStatusCode(200)
                         .withStartupTimeout(Duration.ofMinutes(7)));
 
-        FINERACT.start();
+        return fineract;
+    }
+
+    /**
+     * Registers a second tenant against a copy of the migrated default tenant database.
+     *
+     * <p>The connection row is copied from the default tenant's, which carries the encrypted schema
+     * password and the master password hash it was encrypted under. Both are needed: without the
+     * hash Apache Fineract fails to decrypt the password and refuses to start.
+     */
+    private static void registerSecondTenant() {
+        psql("postgres", "CREATE DATABASE " + SECOND_TENANT_DB + ";");
+
+        // pg_dump rather than a TEMPLATE copy, which Postgres refuses while Fineract holds
+        // connections to the source database. bash and pipefail because the pipeline's status is
+        // otherwise psql's alone: a pg_dump that failed would leave the copy incomplete, and the
+        // registration would carry on against an empty database.
+        Container.ExecResult copy = exec(
+                POSTGRES,
+                "bash",
+                "-c",
+                "set -o pipefail; pg_dump -U postgres " + DEFAULT_TENANT_DB
+                        + " | psql -q -v ON_ERROR_STOP=1 -U postgres " + SECOND_TENANT_DB + " >/dev/null");
+        if (copy.getExitCode() != 0) {
+            throw new IllegalStateException(
+                    "Copying " + DEFAULT_TENANT_DB + " into " + SECOND_TENANT_DB + " failed: " + copy.getStderr());
+        }
+
+        psql(
+                "fineract_tenants",
+                "INSERT INTO tenant_server_connections ("
+                        + "  schema_server, schema_name, schema_server_port, schema_username, schema_password,"
+                        + "  auto_update, master_password_hash)"
+                        + " SELECT schema_server, '" + SECOND_TENANT_DB + "', schema_server_port, schema_username,"
+                        + "  schema_password, auto_update, master_password_hash"
+                        + " FROM tenant_server_connections WHERE id = 1;");
+
+        psql(
+                "fineract_tenants",
+                "INSERT INTO tenants (identifier, name, timezone_id, oltp_id, report_id)"
+                        + " SELECT '" + SECOND_TENANT + "', 'Second Tenant', timezone_id,"
+                        + "  (SELECT MAX(id) FROM tenant_server_connections),"
+                        + "  (SELECT MAX(id) FROM tenant_server_connections)"
+                        + " FROM tenants WHERE id = 1;");
+    }
+
+    private static void psql(String database, String sql) {
+        Container.ExecResult result = exec(POSTGRES, "psql", "-U", "postgres", "-d", database, "-c", sql);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException("psql failed on " + database + ": " + result.getStderr());
+        }
+    }
+
+    private static Container.ExecResult exec(GenericContainer<?> container, String... command) {
+        try {
+            return container.execInContainer(command);
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException(e);
+        }
     }
 
     @BeforeAll
@@ -121,14 +272,12 @@ public abstract class BirtIntegrationTestBase {
         return FINERACT.getMappedPort(8443);
     }
 
+    /** The directory the plugin should store {@code tenant}'s uploaded designs in, on the host. */
+    protected static Path tenantReportsDir(String tenant) {
+        return REPORTS_DIR.resolve(tenant);
+    }
+
     protected static Container.ExecResult execPostgres(String... command) {
-        try {
-            return POSTGRES.execInContainer(command);
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw new RuntimeException(e);
-        }
+        return exec(POSTGRES, command);
     }
 }

--- a/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtReportUploadIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/integration/BirtReportUploadIntegrationTest.java
@@ -1,0 +1,360 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * End-to-end coverage of WEB-1200: installing an Eclipse BIRT report design through the API.
+ *
+ * <p>Every assertion about where a design ends up is made against the host side of the directory
+ * bound into the container, so these tests prove the file really is written to the authenticated
+ * tenant's directory rather than merely that the endpoint answered 200.
+ */
+@DisplayName("BIRT Report Design Upload E2E Tests")
+class BirtReportUploadIntegrationTest extends BirtIntegrationTestBase {
+
+    private static final String UPLOAD_PATH = "/fineract-provider/api/v1/birt/reports";
+    private static final String SUPER_USER_AUTH = basicAuth("mifos", "password");
+
+    private static final String DESIGN_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+              <property name="units">in</property>
+              <body/>
+            </report>
+            """;
+
+    /** A user granted CREATE_REPORT and nothing else. */
+    private static String createReportUserAuth;
+
+    /** A user granted ALL_FUNCTIONS_READ, which must not be enough to install a design. */
+    private static String readOnlyUserAuth;
+
+    private static String basicAuth(String username, String password) {
+        return "Basic "
+                + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static RequestSpecification spec(String tenant, String authorization) {
+        return new RequestSpecBuilder()
+                .setBaseUri("https://" + FINERACT.getHost() + ":" + getFineractPort())
+                .setRelaxedHTTPSValidation()
+                .addHeader("Fineract-Platform-TenantId", tenant)
+                .addHeader("Authorization", authorization)
+                .build();
+    }
+
+    @BeforeAll
+    void createUsersWithSpecificGrants() {
+        createReportUserAuth = createUser("web1200_creator", "CREATE_REPORT");
+        readOnlyUserAuth = createUser("web1200_reader", "ALL_FUNCTIONS_READ");
+    }
+
+    /** Creates a role holding exactly one permission, and a user in it. Returns its auth header. */
+    private String createUser(String username, String permission) {
+        final String password = "Web1204!setup9";
+
+        int roleId = given().spec(spec(DEFAULT_TENANT, SUPER_USER_AUTH))
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"" + username + "_role\",\"description\":\"WEB-1200 test role\"}")
+                .when()
+                .post("/fineract-provider/api/v1/roles")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("resourceId");
+
+        given().spec(spec(DEFAULT_TENANT, SUPER_USER_AUTH))
+                .contentType(ContentType.JSON)
+                .body("{\"permissions\":{\"" + permission + "\":true}}")
+                .when()
+                .put("/fineract-provider/api/v1/roles/" + roleId + "/permissions")
+                .then()
+                .statusCode(200);
+
+        given().spec(spec(DEFAULT_TENANT, SUPER_USER_AUTH))
+                .contentType(ContentType.JSON)
+                .body("{\"username\":\"" + username + "\",\"firstname\":\"Web\",\"lastname\":\"Twelve\","
+                        + "\"email\":\"" + username + "@example.com\",\"officeId\":1,\"roles\":[" + roleId + "],"
+                        + "\"sendPasswordToEmail\":false,\"password\":\"" + password + "\","
+                        + "\"repeatPassword\":\"" + password + "\"}")
+                .when()
+                .post("/fineract-provider/api/v1/users")
+                .then()
+                .statusCode(200);
+
+        return basicAuth(username, password);
+    }
+
+    private io.restassured.response.Response upload(
+            String tenant, String authorization, String fileName, byte[] content) {
+        return given().spec(spec(tenant, authorization))
+                .multiPart("file", fileName, content)
+                .when()
+                .post(UPLOAD_PATH);
+    }
+
+    private io.restassured.response.Response upload(String tenant, String fileName, String content) {
+        return upload(tenant, SUPER_USER_AUTH, fileName, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("Stores an uploaded design in the authenticated tenant's own directory")
+    void storesDesignInTheTenantDirectory() throws IOException {
+        String fileName = "WEB1200 Stored.rptdesign";
+
+        upload(DEFAULT_TENANT, fileName, DESIGN_XML)
+                .then()
+                .statusCode(200)
+                .body("fileName", org.hamcrest.Matchers.equalTo(fileName))
+                .body("reportName", org.hamcrest.Matchers.equalTo("WEB1200 Stored"))
+                .body("overwritten", org.hamcrest.Matchers.is(false))
+                .body("size", org.hamcrest.Matchers.greaterThan(0));
+
+        Path stored = tenantReportsDir(DEFAULT_TENANT).resolve(fileName);
+        assertTrue(Files.isRegularFile(stored), "design should be written to " + stored);
+        assertEquals(DESIGN_XML, Files.readString(stored));
+
+        // It must not have been written to the shared directory the caller never named.
+        assertFalse(Files.exists(REPORTS_DIR.resolve(fileName)), "design must not land in the shared directory");
+    }
+
+    @Test
+    @DisplayName("Each tenant gets its own copy and cannot reach the other's")
+    void tenantsAreIsolated() throws IOException {
+        String fileName = "WEB1200 Isolation.rptdesign";
+        String defaultDesign = DESIGN_XML.replace("<body/>", "<body><!--default--></body>");
+        String secondDesign = DESIGN_XML.replace("<body/>", "<body><!--second--></body>");
+
+        upload(DEFAULT_TENANT, fileName, defaultDesign).then().statusCode(200);
+        upload(SECOND_TENANT, fileName, secondDesign).then().statusCode(200);
+
+        Path forDefault = tenantReportsDir(DEFAULT_TENANT).resolve(fileName);
+        Path forSecond = tenantReportsDir(SECOND_TENANT).resolve(fileName);
+
+        assertEquals(defaultDesign, Files.readString(forDefault), "tenant A's design was modified by tenant B");
+        assertEquals(secondDesign, Files.readString(forSecond));
+    }
+
+    @Test
+    @DisplayName("A tenant cannot write into another tenant's directory by naming it")
+    void cannotEscapeIntoAnotherTenantsDirectory() throws IOException {
+        String victim = "WEB1200 Victim.rptdesign";
+        upload(DEFAULT_TENANT, victim, DESIGN_XML).then().statusCode(200);
+
+        // Tenant "second" tries to overwrite tenant "default"'s design by climbing out of its own
+        // directory. The name is refused outright.
+        upload(SECOND_TENANT, "../" + DEFAULT_TENANT + "/" + victim, "<report>hijacked</report>")
+                .then()
+                .statusCode(400);
+
+        assertEquals(
+                DESIGN_XML,
+                Files.readString(tenantReportsDir(DEFAULT_TENANT).resolve(victim)),
+                "another tenant's design must be untouched");
+    }
+
+    @Test
+    @DisplayName("Re-uploading the same name replaces the design and reports it")
+    void overwritesAnExistingDesign() throws IOException {
+        String fileName = "WEB1200 Overwrite.rptdesign";
+        String replacement = DESIGN_XML.replace("<body/>", "<body><!--v2--></body>");
+
+        upload(DEFAULT_TENANT, fileName, DESIGN_XML).then().statusCode(200);
+        upload(DEFAULT_TENANT, fileName, replacement)
+                .then()
+                .statusCode(200)
+                .body("overwritten", org.hamcrest.Matchers.is(true));
+
+        assertEquals(
+                replacement, Files.readString(tenantReportsDir(DEFAULT_TENANT).resolve(fileName)));
+    }
+
+    @Test
+    @DisplayName("A rejected upload leaves the design already installed intact")
+    void rejectedUploadDoesNotTruncateTheExistingDesign() throws IOException {
+        String fileName = "WEB1200 Intact.rptdesign";
+        upload(DEFAULT_TENANT, fileName, DESIGN_XML).then().statusCode(200);
+
+        upload(DEFAULT_TENANT, fileName, "%PDF-1.7 this is not a report at all")
+                .then()
+                .statusCode(400);
+
+        assertEquals(
+                DESIGN_XML,
+                Files.readString(tenantReportsDir(DEFAULT_TENANT).resolve(fileName)),
+                "a refused upload must not damage the installed design");
+    }
+
+    @ParameterizedTest(name = "rejects {0}")
+    @ValueSource(strings = {"report.pdf", "report.xml", "report.txt", "report.zip", "report.json", "report.prpt"})
+    @DisplayName("Only .rptdesign is accepted")
+    void rejectsOtherExtensions(String fileName) {
+        upload(DEFAULT_TENANT, fileName, DESIGN_XML).then().statusCode(400);
+        assertFalse(Files.exists(tenantReportsDir(DEFAULT_TENANT).resolve(fileName)));
+    }
+
+    @ParameterizedTest(name = "rejects {0}")
+    @ValueSource(
+            strings = {
+                "../escaped.rptdesign",
+                "../../../etc/escaped.rptdesign",
+                "nested/escaped.rptdesign",
+                "nested\\escaped.rptdesign",
+                "/etc/escaped.rptdesign"
+            })
+    @DisplayName("A file name carrying a path is refused")
+    void rejectsPathTraversal(String fileName) {
+        upload(DEFAULT_TENANT, fileName, DESIGN_XML).then().statusCode(400);
+    }
+
+    @Test
+    @DisplayName("Content that is not a BIRT design is refused")
+    void rejectsContentThatIsNotADesign() {
+        upload(DEFAULT_TENANT, "WEB1200 NotXml.rptdesign", "%PDF-1.7 binary junk")
+                .then()
+                .statusCode(400);
+        upload(DEFAULT_TENANT, "WEB1200 WrongRoot.rptdesign", "<catalog><book/></catalog>")
+                .then()
+                .statusCode(400);
+        upload(DEFAULT_TENANT, "WEB1200 Malformed.rptdesign", "<report><unclosed>")
+                .then()
+                .statusCode(400);
+        upload(
+                        DEFAULT_TENANT,
+                        "WEB1200 WrongNamespace.rptdesign",
+                        "<report xmlns=\"http://example.com/not-birt\"><body/></report>")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("A design declaring a doctype is refused rather than resolved")
+    void rejectsExternalEntities() {
+        String xxe = "<?xml version=\"1.0\"?><!DOCTYPE report [<!ENTITY x SYSTEM \"file:///etc/passwd\">]>"
+                + "<report xmlns=\"http://www.eclipse.org/birt/2005/design\"><body>&x;</body></report>";
+
+        upload(DEFAULT_TENANT, "WEB1200 Xxe.rptdesign", xxe).then().statusCode(400);
+    }
+
+    @Test
+    @DisplayName("An empty design is refused")
+    void rejectsAnEmptyDesign() {
+        upload(DEFAULT_TENANT, "WEB1200 Empty.rptdesign", "").then().statusCode(400);
+    }
+
+    @Test
+    @DisplayName("A design over the size limit is refused")
+    void rejectsAnOversizedDesign() {
+        String oversized = "<report>" + "x".repeat(5 * 1024 * 1024) + "</report>";
+
+        upload(DEFAULT_TENANT, "WEB1200 Huge.rptdesign", oversized).then().statusCode(400);
+        assertFalse(Files.exists(tenantReportsDir(DEFAULT_TENANT).resolve("WEB1200 Huge.rptdesign")));
+    }
+
+    @Test
+    @DisplayName("CREATE_REPORT is enough to install a design")
+    void createReportPermissionIsAccepted() {
+        upload(
+                        DEFAULT_TENANT,
+                        createReportUserAuth,
+                        "WEB1200 ByCreator.rptdesign",
+                        DESIGN_XML.getBytes(StandardCharsets.UTF_8))
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("ALL_FUNCTIONS is enough to install a design")
+    void superUserIsAccepted() {
+        upload(DEFAULT_TENANT, "WEB1200 BySuperUser.rptdesign", DESIGN_XML)
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("ALL_FUNCTIONS_READ is not enough, and nothing is written")
+    void readOnlyUserIsRefused() {
+        String fileName = "WEB1200 ByReader.rptdesign";
+
+        upload(DEFAULT_TENANT, readOnlyUserAuth, fileName, DESIGN_XML.getBytes(StandardCharsets.UTF_8))
+                .then()
+                .statusCode(403);
+
+        assertFalse(
+                Files.exists(tenantReportsDir(DEFAULT_TENANT).resolve(fileName)),
+                "an unauthorised upload must not write anything");
+    }
+
+    @Test
+    @DisplayName("An unauthenticated request is refused")
+    void unauthenticatedRequestIsRefused() {
+        given().spec(spec(DEFAULT_TENANT, basicAuth("mifos", "wrong-password")))
+                .multiPart("file", "WEB1200 NoAuth.rptdesign", DESIGN_XML.getBytes(StandardCharsets.UTF_8))
+                .when()
+                .post(UPLOAD_PATH)
+                .then()
+                .statusCode(401);
+    }
+
+    /**
+     * The strongest statement these tests can make: a design that arrived through the endpoint is the
+     * one the reporting engine then renders.
+     *
+     * <p>The shipped {@code Active_Loans_Details} report is registered in the catalogue and runs from
+     * the shared directory. Uploading it installs it in the tenant's own directory, where the loader
+     * looks first, so a run that still succeeds is rendering the uploaded bytes.
+     */
+    @Test
+    @DisplayName("A design installed through the API is what the engine renders")
+    void uploadedDesignIsRenderedByTheEngine() throws IOException {
+        byte[] shipped = Files.readAllBytes(REPORTS_DIR.resolve("Active_Loans_Details.rptdesign"));
+
+        upload(DEFAULT_TENANT, SUPER_USER_AUTH, "Active_Loans_Details.rptdesign", shipped)
+                .then()
+                .statusCode(200);
+
+        assertTrue(Files.isRegularFile(tenantReportsDir(DEFAULT_TENANT).resolve("Active_Loans_Details.rptdesign")));
+
+        given().spec(spec(DEFAULT_TENANT, SUPER_USER_AUTH))
+                .queryParam("tenantIdentifier", DEFAULT_TENANT)
+                .queryParam("output-type", "PDF")
+                .queryParam("locale", "en")
+                .queryParam("dateFormat", "dd MMMM yyyy")
+                .queryParam("R_branch", "1")
+                .queryParam("R_loanOfficer", "-1")
+                .queryParam("R_loanPurposeId", "-1")
+                .queryParam("R_loanProductId", "-1")
+                .queryParam("R_fundId", "-1")
+                .queryParam("R_currencyId", "-1")
+                .queryParam("R_startDate", "01 January 2020")
+                .queryParam("R_endDate", "01 January 2030")
+                .when()
+                .get("/fineract-provider/api/v1/runreports/Active_Loans_Details")
+                .then()
+                .statusCode(200)
+                .contentType("application/pdf");
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportLoaderTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportLoaderTest.java
@@ -8,9 +8,10 @@ package org.apache.fineract.infrastructure.report.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,26 +20,33 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
 import org.eclipse.birt.report.engine.api.EngineException;
 import org.eclipse.birt.report.engine.api.IReportEngine;
 import org.eclipse.birt.report.engine.api.IReportRunnable;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.cache.CacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("BirtReportLoader Tests")
 class BirtReportLoaderTest {
+
+    private static final String TENANT = "tenantA";
 
     @Mock
     private IReportEngine reportEngine;
@@ -47,9 +55,14 @@ class BirtReportLoaderTest {
     private BirtPluginProperties birtProperties;
 
     @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
     private ReportErrorHandler reportErrorHandler;
 
-    @InjectMocks
+    @Mock
+    private CacheManager cacheManager;
+
     private BirtReportLoader reportLoader;
 
     @TempDir
@@ -63,11 +76,19 @@ class BirtReportLoaderTest {
      */
     private Path reportsDir;
 
+    /** A sibling of {@link #reportsDir}, so a name can genuinely try to climb out of it. */
+    private Path outsideDir;
+
     @BeforeEach
     void setUp() throws EngineException, java.io.IOException {
-        reportsDir = tempDir.resolve("reports");
-        Files.createDirectories(reportsDir);
+        ThreadLocalContextUtil.setTenant(
+                FineractPlatformTenant.builder().tenantIdentifier(TENANT).build());
+
+        reportsDir = Files.createDirectories(tempDir.resolve("reports"));
+        outsideDir = Files.createDirectories(tempDir.resolve("outside"));
         when(birtProperties.getReportsPath()).thenReturn(reportsDir.toString());
+        reportLoader = new BirtReportLoader(
+                reportEngine, new BirtReportsDirectory(birtProperties, jdbcTemplate), reportErrorHandler, cacheManager);
 
         // Mock error handler - will be used only in failure cases
         when(reportErrorHandler.reportError(anyString(), anyString())).thenAnswer(invocation -> {
@@ -80,6 +101,11 @@ class BirtReportLoaderTest {
         IReportRunnable mockReport = mock(IReportRunnable.class);
         when(mockReport.getDesignHandle()).thenReturn(mock(org.eclipse.birt.report.model.api.ReportDesignHandle.class));
         when(reportEngine.openReportDesign(anyString())).thenReturn(mockReport);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.clearTenant();
     }
 
     @Test
@@ -112,13 +138,56 @@ class BirtReportLoaderTest {
     }
 
     @Test
-    @DisplayName("Should reject a report name that climbs out of the reports directory")
-    void shouldRejectReportNameEscapingTheReportsDirectory() throws Exception {
-        Path outside = tempDir.resolve("outside.rptdesign");
-        Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
+    @DisplayName("Should prefer the tenant's own design over the shared one")
+    void shouldPreferTenantDesignOverSharedDesign() throws Exception {
+        Files.writeString(reportsDir.resolve("sample.rptdesign"), "<report>shared</report>");
+        Path tenantDir = Files.createDirectories(reportsDir.resolve(TENANT));
+        Path tenantDesign = tenantDir.resolve("sample.rptdesign");
+        Files.writeString(tenantDesign, "<report>tenant</report>");
+
+        reportLoader.loadReport("sample", null);
+
+        ArgumentCaptor<String> openedPath = ArgumentCaptor.forClass(String.class);
+        verify(reportEngine).openReportDesign(openedPath.capture());
+        assertEquals(tenantDesign.toRealPath().toString(), openedPath.getValue());
+    }
+
+    /**
+     * A design that exists is what makes this a confinement test: were the escaped target absent,
+     * the loader would report it as not found without ever deciding whether it was allowed to read
+     * it, and the assertion would pass while testing nothing.
+     */
+    @Test
+    @DisplayName("Should refuse a report name that climbs out of the reports directory")
+    void shouldRefuseReportNameEscapingTheReportsDirectory() throws Exception {
+        Path escaped = outsideDir.resolve("escaped.rptdesign");
+        Files.writeString(escaped, "<?xml version=\"1.0\"?><report></report>");
+        assertTrue(Files.isRegularFile(escaped));
+
+        String escapingName = "../" + outsideDir.getFileName() + "/escaped";
 
         PlatformDataIntegrityException ex =
-                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("../outside", null));
+                assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport(escapingName, null));
+
+        assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
+        verify(reportEngine, never()).openReportDesign(anyString());
+    }
+
+    /**
+     * The tenant's own directory is what separates one tenant's designs from another's, so a nested
+     * name that walks into another tenant's directory has to be refused rather than merely confined:
+     * it stays inside the shared base directory, which containment alone would allow.
+     */
+    @Test
+    @DisplayName("Should refuse a nested report name that names another tenant's directory")
+    void shouldRefuseNestedReportNameNamingAnotherTenant() throws Exception {
+        Path otherTenantDir = Files.createDirectories(reportsDir.resolve("tenantB"));
+        Path otherDesign = otherTenantDir.resolve("Private.rptdesign");
+        Files.writeString(otherDesign, "<?xml version=\"1.0\"?><report></report>");
+        assertTrue(Files.isRegularFile(otherDesign));
+
+        PlatformDataIntegrityException ex = assertThrows(
+                PlatformDataIntegrityException.class, () -> reportLoader.loadReport("tenantB/Private", null));
 
         assertEquals("error.msg.reporting.report.not.found", ex.getGlobalisationMessageCode());
         verify(reportEngine, never()).openReportDesign(anyString());
@@ -127,7 +196,7 @@ class BirtReportLoaderTest {
     @Test
     @DisplayName("Should reject an absolute report name")
     void shouldRejectAbsoluteReportName() throws Exception {
-        Path outside = tempDir.resolve("absolute.rptdesign");
+        Path outside = outsideDir.resolve("absolute.rptdesign");
         Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
 
         String absoluteName = outside.toString().replace(".rptdesign", "");
@@ -146,7 +215,7 @@ class BirtReportLoaderTest {
     @Test
     @DisplayName("Should reject a report that is a symlink out of the reports directory")
     void shouldRejectSymlinkEscapingTheReportsDirectory() throws Exception {
-        Path outside = tempDir.resolve("linked.rptdesign");
+        Path outside = outsideDir.resolve("linked.rptdesign");
         Files.writeString(outside, "<?xml version=\"1.0\"?><report></report>");
 
         try {
@@ -170,14 +239,7 @@ class BirtReportLoaderTest {
     @Test
     @DisplayName("Should reject a configured reports directory that is not a path")
     void shouldRejectAConfiguredReportsDirectoryThatIsNotAPath() {
-        when(birtProperties.getReportsPath()).thenReturn("not\u0000a\u0000path");
-        // this path reports through the overload that carries the cause, so it needs its own stub
-        when(reportErrorHandler.reportError(anyString(), anyString(), any())).thenAnswer(invocation -> {
-            final String code = invocation.getArgument(0);
-            final String message = invocation.getArgument(1);
-            throw new PlatformDataIntegrityException(code, message);
-        });
-
+        when(birtProperties.getReportsPath()).thenReturn("not a path");
         PlatformDataIntegrityException ex =
                 assertThrows(PlatformDataIntegrityException.class, () -> reportLoader.loadReport("sample", null));
 
@@ -192,5 +254,36 @@ class BirtReportLoaderTest {
 
         assertFalse(ex.getDefaultUserMessage().contains(reportsDir.toString()));
         assertFalse(ex.getDefaultUserMessage().contains(".rptdesign"));
+    }
+
+    @Test
+    @DisplayName("Should key the design cache by tenant so one tenant cannot serve another's design")
+    void shouldKeyCacheByTenant() {
+        String tenantAKey = reportLoader.buildCacheKey("sample", null);
+
+        ThreadLocalContextUtil.setTenant(
+                FineractPlatformTenant.builder().tenantIdentifier("tenantB").build());
+        String tenantBKey = reportLoader.buildCacheKey("sample", null);
+
+        assertNotEquals(tenantAKey, tenantBKey);
+    }
+
+    /**
+     * Tenant identifiers and report names may both contain the separator, so joining them with it is
+     * not enough: {@code a} with {@code b_c} and {@code a_b} with {@code c} would be one key, and the
+     * cache would hand one tenant the design compiled for another.
+     */
+    @Test
+    @DisplayName("Should not collide when tenant and report names contain the key separator")
+    void shouldNotCollideOnUnderscoresInTenantAndReportNames() {
+        ThreadLocalContextUtil.setTenant(
+                FineractPlatformTenant.builder().tenantIdentifier("a").build());
+        String first = reportLoader.buildCacheKey("b_c", null);
+
+        ThreadLocalContextUtil.setTenant(
+                FineractPlatformTenant.builder().tenantIdentifier("a_b").build());
+        String second = reportLoader.buildCacheKey("c", null);
+
+        assertNotEquals(first, second);
     }
 }

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportUploadServiceTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportUploadServiceTest.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.exception.PlatformInternalServerException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
+import org.apache.fineract.infrastructure.report.data.BirtReportFileUploadData;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("BirtReportUploadService Tests")
+class BirtReportUploadServiceTest {
+
+    private static final String TENANT_A = "tenantA";
+    private static final String TENANT_B = "tenantB";
+    private static final String DESIGN_FILE = "Active Loans.rptdesign";
+    private static final String DESIGN_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+              <body/>
+            </report>
+            """;
+
+    @Mock
+    private BirtPluginProperties birtProperties;
+
+    @Mock
+    private ReportSecurityService reportSecurityService;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private BirtReportsDirectory reportsDirectory;
+    private BirtReportUploadService uploadService;
+
+    @TempDir
+    Path baseDir;
+
+    @BeforeEach
+    void setUp() {
+        when(birtProperties.getReportsPath()).thenReturn(baseDir.toString());
+        reportsDirectory = new BirtReportsDirectory(birtProperties, jdbcTemplate);
+        uploadService = new BirtReportUploadService(reportsDirectory, reportSecurityService);
+        setTenant(TENANT_A);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.clearTenant();
+    }
+
+    private void setTenant(String identifier) {
+        ThreadLocalContextUtil.setTenant(
+                FineractPlatformTenant.builder().tenantIdentifier(identifier).build());
+    }
+
+    private static InputStream stream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Path designIn(String tenant) {
+        return baseDir.resolve(tenant).resolve(DESIGN_FILE);
+    }
+
+    @Test
+    @DisplayName("Stores a valid design in the authenticated tenant's directory")
+    void storesValidDesign() throws Exception {
+        BirtReportFileUploadData result = uploadService.upload(DESIGN_FILE, stream(DESIGN_XML));
+
+        assertTrue(Files.isRegularFile(designIn(TENANT_A)));
+        assertEquals(DESIGN_XML, Files.readString(designIn(TENANT_A)));
+        assertEquals(DESIGN_FILE, result.fileName());
+        assertEquals("Active Loans", result.reportName());
+        assertFalse(result.overwritten());
+        assertEquals(DESIGN_XML.getBytes(StandardCharsets.UTF_8).length, result.size());
+    }
+
+    @Test
+    @DisplayName("Tenant B's upload leaves Tenant A's design of the same name untouched")
+    void tenantsDoNotOverwriteEachOther() throws Exception {
+        uploadService.upload(DESIGN_FILE, stream(DESIGN_XML));
+
+        setTenant(TENANT_B);
+        String tenantBDesign = DESIGN_XML.replace("<body/>", "<body><label id=\"9\"/></body>");
+        uploadService.upload(DESIGN_FILE, stream(tenantBDesign));
+
+        assertEquals(DESIGN_XML, Files.readString(designIn(TENANT_A)));
+        assertEquals(tenantBDesign, Files.readString(designIn(TENANT_B)));
+    }
+
+    @Test
+    @DisplayName("Re-uploading the same name replaces the design and says so")
+    void overwritesAnExistingDesign() throws Exception {
+        uploadService.upload(DESIGN_FILE, stream(DESIGN_XML));
+
+        String replacement = DESIGN_XML.replace("<body/>", "<body><label id=\"9\"/></body>");
+        BirtReportFileUploadData result = uploadService.upload(DESIGN_FILE, stream(replacement));
+
+        assertTrue(result.overwritten());
+        assertEquals(replacement, Files.readString(designIn(TENANT_A)));
+        try (var entries = Files.list(baseDir.resolve(TENANT_A))) {
+            assertEquals(1, entries.count(), "the staged temporary file should not have been left behind");
+        }
+    }
+
+    @ParameterizedTest(name = "rejects \"{0}\"")
+    @ValueSource(
+            strings = {
+                "report.pdf",
+                "report.xml",
+                "report.txt",
+                "report.zip",
+                "report.json",
+                "report.prpt",
+                "report",
+                ".rptdesign",
+                "report.rptdesign.exe"
+            })
+    @DisplayName("Only .rptdesign is accepted")
+    void rejectsOtherExtensions(String fileName) {
+        assertThrows(
+                PlatformApiDataValidationException.class, () -> uploadService.upload(fileName, stream(DESIGN_XML)));
+    }
+
+    @ParameterizedTest(name = "rejects \"{0}\"")
+    @ValueSource(
+            strings = {
+                "../escaped.rptdesign",
+                "../../../etc/escaped.rptdesign",
+                "nested/escaped.rptdesign",
+                "nested\\escaped.rptdesign",
+                "/etc/escaped.rptdesign"
+            })
+    @DisplayName("A file name carrying a path is rejected and nothing is written")
+    void rejectsPathTraversal(String fileName) throws Exception {
+        assertThrows(
+                PlatformApiDataValidationException.class, () -> uploadService.upload(fileName, stream(DESIGN_XML)));
+
+        try (var entries = Files.walk(baseDir)) {
+            assertEquals(1, entries.count(), "nothing should have been written anywhere under the reports directory");
+        }
+    }
+
+    @Test
+    @DisplayName("A file that is not a BIRT design is rejected")
+    void rejectsContentThatIsNotADesign() {
+        assertThrows(
+                PlatformApiDataValidationException.class,
+                () -> uploadService.upload(DESIGN_FILE, stream("%PDF-1.7 not xml at all")));
+        assertThrows(
+                PlatformApiDataValidationException.class,
+                () -> uploadService.upload(DESIGN_FILE, stream("<catalog><book/></catalog>")));
+        assertFalse(Files.exists(designIn(TENANT_A)));
+    }
+
+    @Test
+    @DisplayName("A design declaring a doctype is rejected rather than resolved")
+    void rejectsDoctypeDeclarations() {
+        String withDoctype = "<?xml version=\"1.0\"?><!DOCTYPE report [<!ENTITY x SYSTEM \"file:///etc/passwd\">]>"
+                + "<report xmlns=\"http://www.eclipse.org/birt/2005/design\"><body>&x;</body></report>";
+
+        assertThrows(
+                PlatformApiDataValidationException.class, () -> uploadService.upload(DESIGN_FILE, stream(withDoctype)));
+    }
+
+    @Test
+    @DisplayName("An empty file is rejected")
+    void rejectsAnEmptyFile() {
+        assertThrows(PlatformApiDataValidationException.class, () -> uploadService.upload(DESIGN_FILE, stream("")));
+    }
+
+    @Test
+    @DisplayName("A design over the size limit is rejected on what is read, not on a declared length")
+    void rejectsAnOversizedDesign() {
+        String oversized = "<report>" + "x".repeat((int) BirtReportUploadService.MAX_DESIGN_SIZE_BYTES) + "</report>";
+
+        assertThrows(
+                PlatformApiDataValidationException.class, () -> uploadService.upload(DESIGN_FILE, stream(oversized)));
+        assertFalse(Files.exists(designIn(TENANT_A)));
+    }
+
+    @Test
+    @DisplayName("A user without CREATE_REPORT is refused before the file is read")
+    void refusesAnUnauthorisedUser() {
+        doThrow(new NoAuthorizationException("The authenticated user does not have the CREATE_REPORT permission."))
+                .when(reportSecurityService)
+                .checkCreateReportPermission();
+
+        assertThrows(NoAuthorizationException.class, () -> uploadService.upload(DESIGN_FILE, stream(DESIGN_XML)));
+        assertFalse(Files.exists(baseDir.resolve(TENANT_A)));
+    }
+
+    @Test
+    @DisplayName("Authorization is checked before anything else")
+    void checksAuthorizationFirst() {
+        doThrow(new NoAuthorizationException("nope"))
+                .when(reportSecurityService)
+                .checkCreateReportPermission();
+
+        assertThrows(NoAuthorizationException.class, () -> uploadService.upload("report.pdf", stream("junk")));
+    }
+
+    @Test
+    @DisplayName("A storage failure surfaces as a server error, not as a success")
+    void reportsAStorageFailure() throws Exception {
+        // A regular file where the tenant directory has to go: the directory cannot be created.
+        Files.writeString(baseDir.resolve(TENANT_A), "in the way");
+
+        assertThrows(
+                PlatformInternalServerException.class, () -> uploadService.upload(DESIGN_FILE, stream(DESIGN_XML)));
+    }
+
+    @Test
+    @DisplayName("A failing stream surfaces as a server error and writes nothing")
+    void reportsAFailingStream() throws Exception {
+        InputStream failing = new InputStream() {
+
+            @Override
+            public int read() throws IOException {
+                throw new IOException("connection reset");
+            }
+        };
+
+        assertThrows(PlatformInternalServerException.class, () -> uploadService.upload(DESIGN_FILE, failing));
+        assertFalse(Files.exists(designIn(TENANT_A)));
+    }
+
+    @Test
+    @DisplayName("Nothing is written when the file name is missing")
+    void rejectsAMissingFileName() {
+        assertThrows(PlatformApiDataValidationException.class, () -> uploadService.upload(null, stream(DESIGN_XML)));
+        verify(reportSecurityService).checkCreateReportPermission();
+    }
+
+    @Test
+    @DisplayName("Nothing is written when no file part is present")
+    void rejectsAMissingFile() {
+        assertThrows(PlatformApiDataValidationException.class, () -> uploadService.upload(DESIGN_FILE, null));
+        assertFalse(Files.exists(designIn(TENANT_A)));
+        assertFalse(Files.exists(baseDir.resolve(TENANT_A)), "no tenant directory should have been created");
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportsDirectoryTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/BirtReportsDirectoryTest.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.infrastructure.report.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.report.config.BirtPluginProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("BirtReportsDirectory Tests")
+class BirtReportsDirectoryTest {
+
+    private static final String TENANT_A = "tenantA";
+    private static final String TENANT_B = "tenantB";
+
+    @Mock
+    private BirtPluginProperties birtProperties;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private BirtReportsDirectory reportsDirectory;
+
+    @TempDir
+    Path baseDir;
+
+    @BeforeEach
+    void setUp() {
+        when(birtProperties.getReportsPath()).thenReturn(baseDir.toString());
+        reportsDirectory = new BirtReportsDirectory(birtProperties, jdbcTemplate);
+        setTenant(TENANT_A);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.clearTenant();
+    }
+
+    private void setTenant(String identifier) {
+        ThreadLocalContextUtil.setTenant(
+                FineractPlatformTenant.builder().tenantIdentifier(identifier).build());
+    }
+
+    @Test
+    @DisplayName("Writes go to a directory named for the authenticated tenant")
+    void writeGoesToTheTenantDirectory() throws Exception {
+        Path target = reportsDirectory.resolveForWrite("Active Loans.rptdesign");
+
+        assertEquals(baseDir.toRealPath().resolve(TENANT_A).resolve("Active Loans.rptdesign"), target);
+        assertTrue(Files.isDirectory(baseDir.resolve(TENANT_A)), "the tenant directory should have been created");
+    }
+
+    @Test
+    @DisplayName("Two tenants resolve to two different destinations for the same file name")
+    void twoTenantsGetSeparateDestinations() throws Exception {
+        Path forTenantA = reportsDirectory.resolveForWrite("Active Loans.rptdesign");
+
+        setTenant(TENANT_B);
+        Path forTenantB = reportsDirectory.resolveForWrite("Active Loans.rptdesign");
+
+        assertFalse(forTenantA.equals(forTenantB), "each tenant must get its own destination");
+        assertTrue(forTenantB.startsWith(baseDir.toRealPath().resolve(TENANT_B)));
+    }
+
+    @ParameterizedTest(name = "refuses to write to \"{0}\"")
+    @ValueSource(
+            strings = {
+                "../escaped.rptdesign",
+                "../../escaped.rptdesign",
+                "nested/escaped.rptdesign",
+                "/etc/escaped.rptdesign"
+            })
+    @DisplayName("A name that leaves the tenant directory is refused")
+    void refusesNamesLeavingTheTenantDirectory(String fileName) {
+        assertThrows(IllegalArgumentException.class, () -> reportsDirectory.resolveForWrite(fileName));
+    }
+
+    @Test
+    @DisplayName("A read finds the tenant's own design before the shared one")
+    void readPrefersTheTenantDesign() throws Exception {
+        Files.writeString(baseDir.resolve("Active Loans.rptdesign"), "shared");
+        Path tenantDesign = Files.createDirectories(baseDir.resolve(TENANT_A)).resolve("Active Loans.rptdesign");
+        Files.writeString(tenantDesign, "tenant");
+
+        assertEquals(
+                Optional.of(tenantDesign.toRealPath()), reportsDirectory.resolveExisting("Active Loans.rptdesign"));
+    }
+
+    @Test
+    @DisplayName("A read falls back to the shared directory for designs installed by hand")
+    void readFallsBackToTheSharedDirectory() throws Exception {
+        Path shared = baseDir.resolve("Active Loans.rptdesign");
+        Files.writeString(shared, "shared");
+
+        assertEquals(Optional.of(shared.toRealPath()), reportsDirectory.resolveExisting("Active Loans.rptdesign"));
+    }
+
+    @Test
+    @DisplayName("One tenant cannot read another tenant's design")
+    void oneTenantCannotReadAnothersDesign() throws Exception {
+        Path tenantADesign = Files.createDirectories(baseDir.resolve(TENANT_A)).resolve("Private.rptdesign");
+        Files.writeString(tenantADesign, "tenant A only");
+
+        setTenant(TENANT_B);
+
+        assertEquals(Optional.empty(), reportsDirectory.resolveExisting("Private.rptdesign"));
+        assertEquals(Optional.empty(), reportsDirectory.resolveExisting("../" + TENANT_A + "/Private.rptdesign"));
+    }
+
+    /**
+     * The shared directory holds the tenant directories, so a nested name read from it names another
+     * tenant: confining the result to the shared directory is not enough, the name has to land
+     * directly in the directory it was resolved against.
+     */
+    @Test
+    @DisplayName("A nested name naming another tenant's directory is refused")
+    void refusesANestedNameNamingAnotherTenant() throws Exception {
+        Path tenantADesign = Files.createDirectories(baseDir.resolve(TENANT_A)).resolve("Private.rptdesign");
+        Files.writeString(tenantADesign, "tenant A only");
+
+        setTenant(TENANT_B);
+
+        assertEquals(Optional.empty(), reportsDirectory.resolveExisting(TENANT_A + "/Private.rptdesign"));
+    }
+
+    @Test
+    @DisplayName("The base directory comes from the BIRT external service configuration first")
+    void baseDirectoryPrefersTheExternalServiceConfiguration() throws Exception {
+        Path configured = Files.createDirectories(baseDir.resolve("configured"));
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class))).thenReturn(configured.toString());
+
+        assertEquals(configured, reportsDirectory.base());
+    }
+
+    @Test
+    @DisplayName("A missing design resolves to nothing")
+    void missingDesignResolvesToNothing() {
+        assertEquals(Optional.empty(), reportsDirectory.resolveExisting("Nowhere.rptdesign"));
+    }
+
+    @Test
+    @DisplayName("Refuses to resolve anything when no tenant is bound to the thread")
+    void refusesWithoutATenant() {
+        ThreadLocalContextUtil.clearTenant();
+
+        assertThrows(IllegalStateException.class, () -> reportsDirectory.resolveForWrite("Active Loans.rptdesign"));
+    }
+}

--- a/src/test/java/org/apache/fineract/infrastructure/report/service/ReportSecurityServiceTest.java
+++ b/src/test/java/org/apache/fineract/infrastructure/report/service/ReportSecurityServiceTest.java
@@ -9,6 +9,8 @@ package org.apache.fineract.infrastructure.report.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
@@ -73,5 +75,25 @@ class ReportSecurityServiceTest {
         assertThatThrownBy(() -> reportSecurityService.checkReportExecutionPermission("Other_Report"))
                 .isInstanceOf(NoAuthorizationException.class)
                 .hasMessageContaining("Other_Report");
+    }
+
+    @Test
+    @DisplayName("Should allow an upload when the authenticated user is granted CREATE_REPORT")
+    void shouldAllowUploadWhenUserIsGrantedCreateReport() {
+        assertThatCode(() -> reportSecurityService.checkCreateReportPermission())
+                .doesNotThrowAnyException();
+
+        verify(authenticatedUser).validateHasPermissionTo(ReportSecurityService.CREATE_REPORT_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("Should reject an upload when the authenticated user is not granted CREATE_REPORT")
+    void shouldRejectUploadWhenUserIsNotGrantedCreateReport() {
+        doThrow(new NoAuthorizationException("Not authorised"))
+                .when(authenticatedUser)
+                .validateHasPermissionTo(ReportSecurityService.CREATE_REPORT_PERMISSION);
+
+        assertThatThrownBy(() -> reportSecurityService.checkCreateReportPermission())
+                .isInstanceOf(NoAuthorizationException.class);
     }
 }


### PR DESCRIPTION
## Summary

Adds an endpoint for uploading BIRT report designs instead of requiring the `.rptdesign` file to be copied directly onto the Fineract host.

```text
POST /fineract-provider/api/v1/birt/reports
Fineract-Platform-TenantId: <tenant>
Content-Type: multipart/form-data

file=<the .rptdesign>
```

The request contains only the file. Tenant and destination are resolved server-side.

A successful response looks like:

```json
{
  "fileName": "Active Loans.rptdesign",
  "size": 20480,
  "overwritten": false,
  "reportName": "Active Loans"
}
```

This only installs the design. Registering the report in the catalogue remains a separate step.

## Report format

The ticket mentions `.prpt`, but BIRT uses `.rptdesign`. The existing `BirtReportLoader` only loads `.rptdesign` files, while the `.prpt` files in this repository are used by the offline migration tooling.

For that reason, the endpoint accepts `.rptdesign` and rejects `.prpt` and other extensions.

I also decided not to convert `.prpt` files during upload. The existing migration tool can produce a fallback design when conversion fails, which could result in a successful upload that doesn't actually represent the original report.

## Tenant-specific storage

Previously, BIRT reports were loaded from the configured reports directory:

* `mifos.birt.reports-path`
* `MIFOS_BIRT_REPORTS_PATH`
* `~/.mifosx/birtReports/` as the fallback

That directory is shared across tenants.

Uploaded designs are now stored under:

```text
<base>/<tenantIdentifier>/<name>.rptdesign
```

The tenant comes from `ThreadLocalContextUtil`, not from the request.

The loader checks the tenant-specific directory first and then the existing base directory. This keeps manually installed reports working.

Both reading and writing use the new `BirtReportsDirectory` class so the directory resolution logic stays in one place.

## Cache

`BirtReportLoader` previously used `reportName + locale` as its cache key.

With tenant-specific report designs, that could cause a compiled design from one tenant to be reused by another tenant with the same report name.

The cache key now also includes the tenant identifier.

## Validation and security

The endpoint:

* requires `CREATE_REPORT`
* accepts only `.rptdesign`
* validates the filename and prevents path traversal
* resolves the final path before checking directory containment
* validates the BIRT XML structure instead of relying only on the extension
* disables doctypes, external entities and external DTD/schema access
* enforces a 5 MB limit based on bytes actually read
* writes to a temporary file before replacing an existing design

The filename is intentionally validated rather than passed through `FilenameUtils.sanitizeFilename`. Sanitizing would change names such as `Active Loans.rptdesign` and break the lookup for reports with spaces.

Re-uploading a design with the same name replaces the existing file and returns `overwritten: true`. Failed uploads leave the existing design untouched.

## Permission

The endpoint reuses `CREATE_REPORT` rather than introducing a new permission.

This is already the permission used for creating reports in the WebApp, and users with it can already define report SQL. `ALL_FUNCTIONS` is also handled through the existing `AppUser` permission checks, while `ALL_FUNCTIONS_READ` does not grant upload access.

## Fineract integration

No changes are required in `apache/fineract`.

`JerseyConfig.setup()` already registers Spring beans annotated with `@Path`, and the plugin is already included in Fineract's component scan. Multipart support is also already configured.

The required Jersey multipart and Swagger dependencies are already available in Fineract, so they remain `provided` in the plugin.

## Overlap with [#537](https://github.com/openMF/mifos-reporting-plugin/pull/537)

[#537](https://github.com/openMF/mifos-reporting-plugin/pull/537) also changes `BirtReportLoader` and `ReportSecurityService`.

I merged the branches locally. There are four conflicts and they are all straightforward.

For the directory-related conflict, I suggest moving #537's `c_external_service` / `reports_dir` lookup into `BirtReportsDirectory.configuredBaseDirectory()`, since directory resolution is now centralized there.

I've also already moved `ReportSecurityService` to `PlatformSecurityContext` / `AppUser`, which matches the direction of #537.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API for uploading Eclipse BIRT report designs.
  * Supports tenant-specific report storage, shared-report fallback, and replacing existing designs.
  * Upload responses include the stored filename, size, report name, and overwrite status.

* **Security**
  * Restricted uploads to users with report-creation permission.
  * Added validation for file type, size, XML structure, and unsafe filenames.
  * Improved tenant isolation and protection against path traversal and external-entity attacks.

* **Bug Fixes**
  * Prevented report path leakage and cache-key collisions across tenants and report names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->